### PR TITLE
adi_update_tools: Remove mathworks_tools from BUILDS_DEV

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -29,8 +29,7 @@ BUILDS_DEV="linux_image_ADI-scripts:origin/master \
 	iio-fm-radio:origin/master \
 	jesd-eye-scan-gtk:origin/master \
 	diagnostic_report:origin/master \
-	colorimeter:origin/master \
-	mathworks_tools:origin/master"
+	colorimeter:origin/master"
 
 BUILDS_2018_R1="linux_image_ADI-scripts:origin/master \
 	fmcomms1-eeprom-cal:origin/2015_R2 \


### PR DESCRIPTION
Motor control utils are not available anymore on the mathworks_tools
repository. They were removed by: https://github.com/analogdevicesinc/MathWorks_tools/commit/6b679dc3b896c9b74d1a8334064e05ea6c36c4f8

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>