### PR TITLE
adi_update_tools.sh: Add python-scipy and sox

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -86,7 +86,9 @@ rfsom_box ()
 
 	cd /usr/local/src
 
-	sudo apt-get -y install qt5-default gpsd python-gps gpsd-clients libmozjs-24-bin mplayer libx264-142 libncurses5 libreadline5 libreadline-dev libexif12 libexif-dev
+	sudo apt-get -y install qt5-default gpsd python-gps gpsd-clients libmozjs-24-bin \
+		mplayer libx264-142 libncurses5 libreadline5 libreadline-dev libexif12 \
+		libexif-dev python3-scipy sox
 
 	curl -L http://github.com/micha/jsawk/raw/master/jsawk > /tmp/jsawk
 	mv /tmp/jsawk /usr/bin/jsawk


### PR DESCRIPTION
python3-scipy and sox are required by audio loopback test
script on rfsom-box so add them to install

Also split install list on multiple lines

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>