### PR TITLE
adrv9009_multichip_sync.sh: Helper script for MCS on ADRV9009-ZU11EG

### DIFF
--- a/adrv9009_multichip_sync.sh
+++ b/adrv9009_multichip_sync.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Turn off continous SYSREF, and enable GPI SYSREF request
+iio_reg hmc7044 0x5a 0
+
+for i in {0..11}
+do
+  echo Performing MCS step: $i
+
+  iio_attr  -q -d adrv9009-phy multichip_sync $i >/dev/null 2>&1
+  iio_attr  -q -d adrv9009-phy-b multichip_sync $i >/dev/null 2>&1
+
+done


### PR DESCRIPTION
Similar to MCS button in the ADRV9009 IIO Oscilloscope plugin.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>