### PR TITLE
iiod_usbd.init: Add SYSTEM ID to libiio Context Attributes

### DIFF
--- a/iiod_usbd.init
+++ b/iiod_usbd.init
@@ -22,10 +22,17 @@ fi
 
 UDC_NAME="$(ls -1 /sys/class/udc | head -n1)"
 GADGET=/sys/kernel/config/usb_gadget/ffs
+SYSID="$(dmesg | grep axi_sysid | cut -d " " -f 3-)"
 
 case "$1" in
 	start)
 		log_daemon_msg "Starting IIO Daemon" "iiod" || true
+
+		if [ ${#SYSID} -ne 0 ] ; then
+			grep -v '^hdl_system_id' /etc/libiio.ini > /tmp/libiio.ini && mv /tmp/libiio.ini /etc/libiio.ini
+			grep -q '\[Context Attributes\]' /etc/libiio.ini || echo "[Context Attributes]" >> /etc/libiio.ini
+			echo hdl_system_id=${SYSID} >> /etc/libiio.ini
+		fi
 
 		if [ ${#UDC_NAME} -ne 0 ] ; then
 			if [ ! -d /sys/kernel/config/usb_gadget ] ; then


### PR DESCRIPTION
For context attributes from file support - libiio needs to be build with -DWITH_LOCAL_CONFIG=ON
In addition it requires libini (https://github.com/pcercuei/libini)

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>