### PR TITLE
adi_update_tools: Shift iio-oscilloscope to cmake build

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -348,6 +348,11 @@ do
   elif [ $REPO = "mathworks_tools" ]
   then
     cd ./motor_control/linux_utils/
+  elif [ $REPO = "iio-oscilloscope" ]
+  then
+	rm -rf build
+	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE=OFF -Bbuild -H.
+	cd build
   fi
 
   do_build $REPO $TARGET


### PR DESCRIPTION
This patch will use the cmake build option for iio-oscilloscope. It will
fix the issue with deprecated gksudo desktop entry. This has been replaced
with pkexec but only for the cmake build option not for the old make.

Also moving forward cmake will be the default for this tool so it makes
more sense to shift now.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>