### PR TITLE
remove the no longer needed iio.service file

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -298,6 +298,9 @@ do
         /usr/local/bin/iio_* /usr/local/include/iio.h \
         /usr/local/lib/pkgconfig/libiio.pc
 
+    # Remove old services file
+    rm -f /etc/avahi/services/iio.service
+
     # Remove old init.d links
     rm -f /etc/init.d/iiod.sh /etc/init.d/iiod
     update-rc.d -f iiod remove


### PR DESCRIPTION
In older versions of libiio, we used a static avahi service file,
now that we added better support inside iiod, we no longer need this.
It's not included in the libiio installer anymore.

Signed-off-by: Robin Getz <robin.getz@analog.com>