### PR TITLE
adi_update_tools: Check for init system

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -333,6 +333,17 @@ do
     if [ -f libini/libini.c ] ; then
 	EXTRA_CMAKE="-DWITH_LOCAL_CONFIG=ON"
     fi
+
+    if grep -Fxq "/lib/systemd" /sbin/init
+    then
+	EXTRA_CMAKE=$EXTRA_CMAKE" -DWITH_SYSTEMD"
+    elif grep -Fxq "upstart" /sbin/init
+    then
+	EXTRA_CMAKE=$EXTRA_CMAKE" -DWITH_UPSTART"
+    else
+	EXTRA_CMAKE=$EXTRA_CMAKE" -DWITH_SYSVINIT"
+    fi
+
     cmake ${EXTRA_CMAKE} -DPYTHON_BINDINGS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE=OFF -Bbuild -H.
     cd build
   elif [ $REPO = "libad9361-iio" ]


### PR DESCRIPTION
This modication will check for what init system is running on the target and
add cmake extra flags to the configuration.

systemd: -DWITH_SYSTEMD
sysvinit: -DWITH_SYSVINIT
upstart: -DWITH_UPSTART

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>