### PR TITLE
adi_update_tools: Add install prefix for iio-oscilloscope

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -365,7 +365,7 @@ do
   elif [ $REPO = "iio-oscilloscope" ]
   then
 	rm -rf build
-	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE=OFF -Bbuild -H.
+	cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE=OFF -Bbuild -H.
 	cd build
   fi
 


### PR DESCRIPTION
Add CMAKE_INSTALL_PREFIX for iio-oscilloscope.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>