### PR TITLE
adi_update_tools: Add BRANCH when checking out for the first time

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -249,8 +249,11 @@ do
     git checkout -f $BRANCH 2>/dev/null
     cd ..
   else
-    echo "\n *** Cloning $REPO ***"
+    echo "\n *** Cloning $REPO/$BRANCH ***"
     git clone https://github.com/analogdevicesinc/$REPO.git || continue
+    cd ./$REPO
+    git checkout $BRANCH || continue
+    cd ..
   fi
 
   echo "\n *** Building $REPO ***"


### PR DESCRIPTION
Add BRANCH option when a repository is cloned for the first time. Before
this change the builds ran from master branch.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>