### PR TITLE
usb-gadget-service: Add dependency on systemd-udev-settle.service

### DIFF
--- a/usb-gadget-service/systemd/iiod_ffs.service
+++ b/usb-gadget-service/systemd/iiod_ffs.service
@@ -8,8 +8,8 @@
 Description=IIO Daemon with USB FFS support
 ConditionPathExists=/sys/bus/iio
 ConditionPathIsMountPoint=/dev/iio_ffs
-Requires=dev-iio_ffs.mount
-After=dev-iio_ffs.mount
+Requires=dev-iio_ffs.mount systemd-udev-settle.service
+After=dev-iio_ffs.mount systemd-udev-settle.service
 Before=gt-start.service
 
 [Service]


### PR DESCRIPTION
IIOD does not handle the hardware changing (in /dev or /sys) after it
has been started. Therefore, we must ensure that all modules have been
loaded before IIOD starts.

Note that this is explicitely marked as a bad practice in systemd docs,
which recommends the service to handle udev events instead. Since IIOD
and libiio don't support hardware hotplug we don't really have a choice
right now, but this workaround should be dropped as soon as hotplug
support has been added.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>