### PR TITLE
test_adrv9002_fh: set sleep in the right place

### DIFF
--- a/test_adrv9002_fh.sh
+++ b/test_adrv9002_fh.sh
@@ -294,9 +294,9 @@ do_tbl_hop() {
 		echo 1 > "/sys/class/gpio/gpio${port_en}/value"
 		# trigger the hop signal. the frame should start on the next hop edge
 		echo 1 > "/sys/class/gpio/gpio${hop_en}/value"
+		sleep 0.1
 		echo 0 > "/sys/class/gpio/gpio${port_en}/value"
 		echo 0 > "/sys/class/gpio/gpio${hop_en}/value"
-		sleep 0.1
 	done
 }
 


### PR DESCRIPTION
The sleep was being done in the end of each iteration. However, it
should be done between starting the frame and stopping it, otherwise it
might become imperceptible to watch the frame on, for example, a
spectrum analyzer.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>