### PR TITLE
adi_update_boot.sh: Replace windows carrige/return

### DIFF
--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -95,7 +95,7 @@ if [ $? -ne 0 ]; then
 fi
 
 ### Convert any windows characters from descriptor file in unix format
-#vim $FILE '+set ff=unix' +wq
+vim $FILE '+set ff=unix' +wq
 
 ### Extract version and release from downloaded file (latest_boot.txt)
 # First line can be boot_master_<timestamp> or boot_<release>_<timestamp>


### PR DESCRIPTION
If boot partition descriptor file ('latest_boot.txt')
contains windows carriage/return, replace it with unix
characters. Otherwise, when the file is parsed, there
will appear "%0D" chars at the end of every line.

Signed-off-by: stefan.raus <stefan.raus@analog.com>