### PR TITLE
usb otg add de10-nano support

### DIFF
--- a/usb_otg.sh
+++ b/usb_otg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Analog Devices, Inc. All Rights Reserved.
+# Copyright (c) 2021-22 Analog Devices, Inc. All Rights Reserved.
 # This software is proprietary to Analog Devices, Inc. and its licensors.
 # By using this software you agree to the terms of the associated
 # Analog Devices Software License Agreement.
@@ -40,7 +40,7 @@ check_platform() {
 }
 
 show_status() {
-	echo "USB_OTG_Status=" $(fdtget -t s $DTB $USB dr_mode)
+	echo "USB dr_mode=" $(fdtget --default "Not Specified: per usb/generic.txt dr_mode should default to otg" --type s $DTB $USB dr_mode)
 }
 
 case "$1" in
@@ -56,13 +56,19 @@ disable)
 	show_status
 	;;
 
+delete_dr_mode)
+	check_platform
+	fdtput -d $DTB $USB dr_mode
+	show_status
+	;;
+
 status)
 	check_platform
 	show_status
 	;;
 
 *)
-	echo "Usage: $0 {enable|disable|status}"
+	echo "Usage: $0 {enable|disable|delete_dr_mode|status}"
 	exit 1
 	;;
 esac

--- a/usb_otg.sh
+++ b/usb_otg.sh
@@ -25,18 +25,20 @@ check_platform() {
 	fi
 
 	if $(is_compatible "xlnx,zynq-7000"); then
-		echo "USB_OTG_Supported=Yes"
 		fdtget -p /boot/devicetree.dtb /axi > /dev/null 2>&1 && USB="/axi/usb@e0002000" || USB="/amba/usb@e0002000"
 		DTB="/boot/devicetree.dtb"
 	elif $(is_compatible "xlnx,zynqmp"); then
-		echo "USB_OTG_Supported=Yes"
 		fdtget -p /boot/devicetree.dtb /axi > /dev/null 2>&1 && USB="/axi/usb0@ff9d0000/dwc3@fe200000" || USB="/amba/usb0@ff9d0000/dwc3@fe200000"
 		DTB="/boot/system.dtb"
+	elif $(is_compatible "altr,socfpga-cyclone5"); then
+		USB="/soc/usb@ffb40000"
+		DTB="/boot/socfpga.dtb"
 	else
 		# All other platform are not supported
-		echo "USB_OTG_Supported=No"
+		echo "USB OtG Supported=No"
 		exit 1
 	fi
+	echo "USB OtG Supported=Yes"
 }
 
 show_status() {


### PR DESCRIPTION
usb_otg.sh: adding support for the DE10-nano platform, and for new delete dr_mode property optino.