### PR TITLE
adi_update_tools: install bindings for libad9166

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -379,7 +379,8 @@ do
   then
 	  rm -rf build
 
-	  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE=OFF -Bbuild -H.
+	  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE=OFF \
+		-DPYTHON_BINDINGS=ON -Bbuild -H.
 	  cd build
   elif [ $REPO = "mathworks_tools" ]
   then


### PR DESCRIPTION
By default enable the option to install python bindings for the
libad9166-iio required for the pyadi-iio cn0511 support.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>