### PR TITLE
Override lightdm timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ install:
 	install -D -m 0644 ./power-service/adi_power.py /usr/share/systemd/
 	install -D -m 0644 ./power-service/stingray_power.py /usr/share/systemd/
 
+	install -D -m 0644 ./lightdm_timeout.conf /etc/systemd/system/lightdm.service.d/timeout.conf
+
 	systemctl daemon-reload
 	systemctl enable adi-power.service
 

--- a/lightdm_timeout.conf
+++ b/lightdm_timeout.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStopSec=5


### PR DESCRIPTION
lightdm gets stuck in a loop trying to start X11 on a board with no screen attached. Add a TimeoutStopSec of 5 seconds to prevent prolonging shutdown sequence for too long.

Signed-off-by: Cosmin Tanislav <demonsingur@gmail.com>