### PR TITLE
adi_update_tools.sh: fix script

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$(id -u)" != "0" ] ; then
 	echo "This script must be run as root"


### PR DESCRIPTION
Change shell from sh to bash, otherwise '[[' and ']]' won't be recognized and the script will give '[[: not found', the switch condition over input parameter won't work properly , going alway on using 'master' branches.