### PR TITLE
iiod_context: fix hdl sysid with colors

### DIFF
--- a/usb-gadget-service/scripts/iiod_context.sh
+++ b/usb-gadget-service/scripts/iiod_context.sh
@@ -20,10 +20,10 @@ SELF=$0
 #some systems have null in the device tree, so replace those with spaces
 #some systems include non-printable chars, or color codes so also remove those.
 sanitize_str() {
-	echo "$@" |  tr '\0' ' ' | sed -e 's/ $//g' -e 's/\x1b\[[0-9;]*m//g' | tr -cd '[:print:]\n'
+	echo "$@" |  tr '\0' ' ' | sed -e 's/ $//g' -e 's/\\x1b\[[0-9;]*m//g' | tr -cd '[:print:]\n'
 }
 sanitize() {
-	cat $1 | tr '\0' ' ' | sed -e 's/ $//g' -e 's/\x1b\[[0-9;]*m//g' | tr -cd '[:print:]\n'
+	cat $1 | tr '\0' ' ' | sed -e 's/ $//g' -e 's/\\x1b\[[0-9;]*m//g' | tr -cd '[:print:]\n'
 }
 
 #run on x86 and ARM


### PR DESCRIPTION
When there are colors codes in the axi sysid strings, the resulting /etc/libiio.ini is wrongly written. Well, this only happens in the second time the file is written. If there's no file, it works for the fist time.

Anyways, this all means that we are unable to get the libiio context from a remote connection.

In commit 06afede486c3 ("iiod_context.sh: remove non-printable chars in dmesg"), we tried to remove the specific color codes from the string but that change is missing to properly escape '\' so that sed actually matches the pattern to remove. Let's fix that...