### PR TITLE
Update to main branches

### DIFF
--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -3,7 +3,7 @@ shopt -s extglob # activate extended pattern matching
 
 ### Set global variables
 REPO="linux_image_ADI-scripts"
-BRANCH="origin/master"
+BRANCH="origin/main"
 SERVER="http://swdownloads.analog.com"
 SPATH="cse/boot_partition_files"
 RPI_SPATH="cse/linux_rpi"
@@ -12,7 +12,7 @@ ARCHIVE_NAME="latest_boot_partition.tar.gz"
 # Whenever 'latest' and 'previous' are updated, need to update also conditions from next if
 LATEST_RELEASE="2021_r2"
 RELEASE=$LATEST_RELEASE
-LATEST_RPI_BRANCH="rpi-5.10.y"
+LATEST_RPI_BRANCH="rpi-5.15.y"
 RPI_BRANCH=$LATEST_RPI_BRANCH
 FILE="latest_boot.txt"
 RPI_FILE="rpi_archives_properties.txt"
@@ -20,13 +20,13 @@ RPI_FILE="rpi_archives_properties.txt"
 ### Allow selective builds. By default use the latest release
 if [ "$1" = "help" -o "$1" = "-h" ]; then
   echo "This script can be called with a parameter to select the release:"
-  echo "  There can be used 'dev'(or 'master') for boot files from master,"
+  echo "  There can be used 'dev'(or 'master' or 'main') for boot files from main,"
   echo "  or a specific release (for example '2019_R2') for specific boot files."
   echo "  By default will use latest released version (right now being $LATEST_RELEASE)."
   exit 0
-elif [ "$1" = "dev"  -o "$1" = "master" ]; then
-  RELEASE="master"
-  RPI_BRANCH="rpi-5.10.y"
+elif [ "$1" = "dev"  -o "$1" = "master" -o "$1" =  "main" ]; then
+  RELEASE="main"
+  RPI_BRANCH="rpi-6.1.y"
 elif [ "$1" = "2019_R1" -o "$1" = "2019_r1" ]; then
   RELEASE="2019_r1"
   RPI_BRANCH="rpi-4.9.y"
@@ -157,7 +157,7 @@ new_release=$(echo $new_release | tr '[:upper:]' '[:lower:]')
 if [ "$current_release" != "$new_release" ]; then
   # Check if files fit on boot partition (for older release including 2019-R2 there is 1 GB, newer ones have 2 GB)
   boot_part_size=$(df -k $FAT_MOUNT | awk '/[0-9]%/{print $(NF-4)}' | sed 's/G//')
-  if [[ "$new_release" =~ *"2021_r1"* ]] || [[ "$new_release" =~ *"2021_r2"* ]] || [[ "$new_release" =~ *"master"* ]]; then
+  if [[ "$new_release" =~ *"2021_r1"* ]] || [[ "$new_release" =~ *"2021_r2"* ]] || [[ "$new_release" =~ *"main"* ]]; then
     if [[ $boot_part_size -lt 1250000 ]]; then
       echo -e "\nWarning! You want to update boot files from a newer release: $new_release (current release: $current_release)"
       echo "But newer releases have the size of boot files more than 1 GB (the size of boot partition used in older releases),"
@@ -332,7 +332,7 @@ restoring_boot_bin()
     fi
   elif [[ "$1" == *"arria10"* ]]; then
     echo -e "\nRestoring socfpga_arria10_socdk.rbf/fit_spl_fpga.itb..."
-    # Restore config depending on release, in master and starting with 2021_R1
+    # Restore config depending on release, in main and starting with 2021_R1
     # there is a different boot flow (starting with Quartus Pro 20.1)
     if [ "$new_release" == "2019_r1" -o "$new_release" == "2019_r2" ]; then
       if [ -e $1/socfpga_arria10_socdk.rbf ]; then
@@ -474,13 +474,13 @@ restoring_extra_files()
 {
   if [[ "$1" == *"cyclone5"* ]]; then
     restoring_u-boot_file "$1/u-boot.scr"
-    # Restore config depending on release, in master and starting with 2021_R1
+    # Restore config depending on release, in main and starting with 2021_R1
     # there is a different boot flow (starting with Quartus Pro 20.1)
     if [ "$new_release" != "2019_r1" ] && [ "$new_release" != "2019_r2" ]; then
       restoring_extlinux $1
     fi
   elif [[ "$1" == *"arria10"* ]]; then
-    # Restore config depending on release, in master and starting with 2021_R1
+    # Restore config depending on release, in main and starting with 2021_R1
     # there is a different boot flow (starting with Quartus Pro 20.1)
     if [ "$new_release" != "2019_r1" ] && [ "$new_release" != "2019_r2" ]; then
       restoring_u-boot_file "$1/u-boot.img"

--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -10,7 +10,7 @@ RPI_SPATH="cse/linux_rpi"
 ARCHIVE_NAME="latest_boot_partition.tar.gz"
 
 # Whenever 'latest' and 'previous' are updated, need to update also conditions from next if
-LATEST_RELEASE="2021_r2"
+LATEST_RELEASE="2022_r2"
 RELEASE=$LATEST_RELEASE
 LATEST_RPI_BRANCH="rpi-5.15.y"
 RPI_BRANCH=$LATEST_RPI_BRANCH
@@ -39,6 +39,9 @@ elif [ "$1" = "2021_R1" -o "$1" = "2021_r1" ]; then
 elif [ "$1" = "2021_R2" -o "$1" = "2021_r2" ]; then
   RELEASE="2021_r2"
   RPI_BRANCH="rpi-5.10.y"
+elif [ "$1" = "2022_R2" -o "$1" = "2022_r2" ]; then
+  RELEASE="2022_r2"
+  RPI_BRANCH="rpi-5.15.y"
 fi
 
 ### Verify if current script is latest version

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -98,6 +98,19 @@ BUILDS_2021_R2="linux_image_ADI-scripts:origin/main \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R2"
 
+BUILDS_2022_R2="linux_image_ADI-scripts:origin/main \
+	libiio:origin/2022_R2 \
+	libad9361-iio:origin/2022_R2 \
+	libad9166-iio:origin/2022_R2 \
+	iio-oscilloscope:origin/2022_R2\
+	fru_tools:origin/2022_R2 \
+	iio-fm-radio:origin/main \
+	wiki-scripts:origin/main \
+	jesd-eye-scan-gtk:origin/2022_R2 \
+	diagnostic_report:origin/main \
+	colorimeter:origin/2022_R2"
+
+
 # Define file where to save git info
 VERSION="/ADI_repos_git_info.txt"
 [ -f $VERSION ] && rm -rf $VERSION
@@ -268,6 +281,9 @@ then
 elif [[ "$1" = "2021_R2" ]] || [[ "$1" = "2021_r2" ]]
 then
   BUILDS=$BUILDS_2021_R2
+elif [[ "$1" = "2022_R2" ]] || [[ "$1" = "2022_r2" ]]
+then
+  BUILDS=$BUILDS_2022_R2
 elif [[ "$1" = "NEXT_STABLE" ]] || [[ "$1" = "next_stable" ]]
 then
   BUILDS=$BUILDS_NEXT_STABLE

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -21,47 +21,47 @@ md5_self=`md5sum $0`
 # repository:branch:make_target
 
 BUILDS_DEV="linux_image_ADI-scripts:origin/master \
-	libiio:origin/master \
-	libad9361-iio:origin/master \
-	libad9166-iio:origin/master \
-	iio-oscilloscope:origin/master \
-	fru_tools:origin/master \
-	iio-fm-radio:origin/master \
-	jesd-eye-scan-gtk:origin/master \
-	diagnostic_report:origin/master \
-	wiki-scripts:origin/master \
-	colorimeter:origin/master"
+	libiio:origin/main \
+	libad9361-iio:origin/main \
+	libad9166-iio:origin/main \
+	iio-oscilloscope:origin/main \
+	fru_tools:origin/main \
+	iio-fm-radio:origin/main \
+	jesd-eye-scan-gtk:origin/main \
+	diagnostic_report:origin/main \
+	wiki-scripts:origin/main \
+	colorimeter:origin/main"
 
 BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/master \
 	libiio:origin/next_stable \
 	libad9361-iio:origin/next_stable \
 	libad9166-iio:origin/next_stable \
 	iio-oscilloscope:origin/next_stable \
-	fru_tools:origin/master \
-	iio-fm-radio:origin/master \
-	jesd-eye-scan-gtk:origin/master \
-	diagnostic_report:origin/master \
-	wiki-scripts:origin/master \
-	colorimeter:origin/master"
+	fru_tools:origin/main \
+	iio-fm-radio:origin/main \
+	jesd-eye-scan-gtk:origin/main \
+	diagnostic_report:origin/main \
+	wiki-scripts:origin/main \
+	colorimeter:origin/main"
 
 BUILDS_2018_R2="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2018_R2 \
-	libad9361-iio:origin/master \
+	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2018_R2\
 	fru_tools:origin/2018_R2 \
 	iio-fm-radio:origin/2015_R2 \
 	jesd-eye-scan-gtk:origin/2018_R2 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2018_R2"
 
 BUILDS_2019_R1="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2019_R1 \
-	libad9361-iio:origin/master \
+	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2019_R1\
 	fru_tools:origin/2019_R1 \
 	iio-fm-radio:origin/2015_R2 \
 	jesd-eye-scan-gtk:origin/2019_R1 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R1"
 
 BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
@@ -71,31 +71,31 @@ BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
 	fru_tools:origin/2019_R2 \
 	iio-fm-radio:origin/2015_R2 \
 	jesd-eye-scan-gtk:origin/2019_R2 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R2"
 
 BUILDS_2021_R1="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2021_R1 \
 	libad9361-iio:origin/2021_R1 \
-	libad9166-iio:origin/master \
+	libad9166-iio:origin/main \
 	iio-oscilloscope:origin/2021_R1\
 	fru_tools:origin/2021_R1 \
-	iio-fm-radio:origin/master \
-	wiki-scripts:origin/master \
+	iio-fm-radio:origin/main \
+	wiki-scripts:origin/main \
 	jesd-eye-scan-gtk:origin/2021_R1 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R1"
 
 BUILDS_2021_R2="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2021_R2 \
 	libad9361-iio:origin/2021_R2 \
-	libad9166-iio:origin/master \
+	libad9166-iio:origin/main \
 	iio-oscilloscope:origin/2021_R2\
-	fru_tools:origin/master \
-	iio-fm-radio:origin/master \
-	wiki-scripts:origin/master \
-	jesd-eye-scan-gtk:origin/master \
-	diagnostic_report:origin/master \
+	fru_tools:origin/main \
+	iio-fm-radio:origin/main \
+	wiki-scripts:origin/main \
+	jesd-eye-scan-gtk:origin/main \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R2"
 
 # Define file where to save git info
@@ -253,7 +253,7 @@ rfsom_box ()
 }
 
 # Allow selective builds by default build the latest release branches
-if [[ "$1" =~ "dev" ]] || [[ "$1" = "master" ]]
+if [[ "$1" =~ "dev" ]] || [[ "$1" = "main" ]]
 then
   BUILDS=$BUILDS_DEV
 elif [[ "$1" = "2019_R1" ]] || [[ "$1" = "2019_r1" ]]
@@ -284,11 +284,11 @@ do
   BRANCH=`echo $i | cut -s -d':' -f2`
   TARGET=`echo $i | cut -s -d':' -f3`
 
-# selective build without branch? use master
+# selective build without branch? use main
   if [ -z $BRANCH ]
   then
     echo HERE
-    BRANCH=origin/master
+    BRANCH=origin/main
     TARGET=""
   fi
 

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -44,36 +44,6 @@ BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/main \
 	wiki-scripts:origin/main \
 	colorimeter:origin/main"
 
-BUILDS_2018_R2="linux_image_ADI-scripts:origin/main \
-	libiio:origin/2018_R2 \
-	libad9361-iio:origin/main \
-	iio-oscilloscope:origin/2018_R2\
-	fru_tools:origin/2018_R2 \
-	iio-fm-radio:origin/2015_R2 \
-	jesd-eye-scan-gtk:origin/2018_R2 \
-	diagnostic_report:origin/main \
-	colorimeter:origin/2018_R2"
-
-BUILDS_2019_R1="linux_image_ADI-scripts:origin/main \
-	libiio:origin/2019_R1 \
-	libad9361-iio:origin/main \
-	iio-oscilloscope:origin/2019_R1\
-	fru_tools:origin/2019_R1 \
-	iio-fm-radio:origin/2015_R2 \
-	jesd-eye-scan-gtk:origin/2019_R1 \
-	diagnostic_report:origin/main \
-	colorimeter:origin/2019_R1"
-
-BUILDS_2019_R2="linux_image_ADI-scripts:origin/main \
-	libiio:origin/2019_R2 \
-	libad9361-iio:origin/2019_R2 \
-	iio-oscilloscope:origin/2019_R2\
-	fru_tools:origin/2019_R2 \
-	iio-fm-radio:origin/2015_R2 \
-	jesd-eye-scan-gtk:origin/2019_R2 \
-	diagnostic_report:origin/main \
-	colorimeter:origin/2019_R2"
-
 BUILDS_2021_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R1 \
 	libad9361-iio:origin/2021_R1 \
@@ -269,12 +239,12 @@ rfsom_box ()
 if [[ "$1" =~ "dev" ]] || [[ "$1" = "main" ]]
 then
   BUILDS=$BUILDS_DEV
-elif [[ "$1" = "2019_R1" ]] || [[ "$1" = "2019_r1" ]]
+elif [[ "$1" = "2018_R2" ]] || [[ "$1" = "2018_r2" ]] || \
+     [[ "$1" = "2019_R1" ]] || [[ "$1" = "2019_r1" ]] || \
+     [[ "$1" = "2019_R2" ]] || [[ "$1" = "2019_r2" ]]
 then
-  BUILDS=$BUILDS_2019_R1
-elif [[ "$1" = "2019_R2" ]] || [[ "$1" = "2019_r2" ]]
-then
-  BUILDS=$BUILDS_2019_R2
+  echo "Only last two releases are supported for update."
+  exit 1
 elif [[ "$1" = "2021_R1" ]] || [[ "$1" = "2021_r1" ]]
 then
   BUILDS=$BUILDS_2021_R1

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -61,10 +61,10 @@ BUILDS_2021_R2="linux_image_ADI-scripts:origin/main \
 	libad9361-iio:origin/2021_R2 \
 	libad9166-iio:origin/main \
 	iio-oscilloscope:origin/2021_R2\
-	fru_tools:origin/main \
+	fru_tools:origin/2021_R2 \
 	iio-fm-radio:origin/main \
 	wiki-scripts:origin/main \
-	jesd-eye-scan-gtk:origin/main \
+	jesd-eye-scan-gtk:origin/2021_R2 \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R2"
 

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -20,7 +20,7 @@ md5_self=`md5sum $0`
 # scripts ...
 # repository:branch:make_target
 
-BUILDS_DEV="linux_image_ADI-scripts:origin/master \
+BUILDS_DEV="linux_image_ADI-scripts:origin/main \
 	libiio:origin/main \
 	libad9361-iio:origin/main \
 	libad9166-iio:origin/main \
@@ -32,7 +32,7 @@ BUILDS_DEV="linux_image_ADI-scripts:origin/master \
 	wiki-scripts:origin/main \
 	colorimeter:origin/main"
 
-BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/master \
+BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/main \
 	libiio:origin/next_stable \
 	libad9361-iio:origin/next_stable \
 	libad9166-iio:origin/next_stable \
@@ -44,7 +44,7 @@ BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/master \
 	wiki-scripts:origin/main \
 	colorimeter:origin/main"
 
-BUILDS_2018_R2="linux_image_ADI-scripts:origin/master \
+BUILDS_2018_R2="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2018_R2 \
 	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2018_R2\
@@ -54,7 +54,7 @@ BUILDS_2018_R2="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2018_R2"
 
-BUILDS_2019_R1="linux_image_ADI-scripts:origin/master \
+BUILDS_2019_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2019_R1 \
 	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2019_R1\
@@ -64,7 +64,7 @@ BUILDS_2019_R1="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R1"
 
-BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
+BUILDS_2019_R2="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2019_R2 \
 	libad9361-iio:origin/2019_R2 \
 	iio-oscilloscope:origin/2019_R2\
@@ -74,7 +74,7 @@ BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R2"
 
-BUILDS_2021_R1="linux_image_ADI-scripts:origin/master \
+BUILDS_2021_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R1 \
 	libad9361-iio:origin/2021_R1 \
 	libad9166-iio:origin/main \
@@ -86,7 +86,7 @@ BUILDS_2021_R1="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R1"
 
-BUILDS_2021_R2="linux_image_ADI-scripts:origin/master \
+BUILDS_2021_R2="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R2 \
 	libad9361-iio:origin/2021_R2 \
 	libad9166-iio:origin/main \


### PR DESCRIPTION
Multiple commits for:
  - change default branches to main for the repos that already have 'main'
  - set "linux_image_ADI-scripts" default to 'main' ('master' won't be deleted yet since old versions of the adi_update_tools.sh script are using it - so whenever 'adi_update_tools.sh' is called from old SD card images)
  - **add case for 2022_r2 release**
  - remove very old releases (2018_r1/2 and 2019_r1//2)
  - fix some branches to be used for 2021_r2 (at this moment they are in sync with main / master, but for cases when there wll be compatibility-breaker commits into main / master)