### PR TITLE
adi_update_boot.sh: keep overlays/overlay_map.dtb

### DIFF
--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -587,7 +587,8 @@ while true
         ### Remove boot partition
         echo "Removing boot files from /boot..."
         cd "$FAT_MOUNT" || exit 1
-        rm -rf !($default_files)
+        rm -f !($default_files)
+        rm -r ./overlays/*.dtbo
         cd - 2>&1 >/dev/null
         ### Extract new files
         echo -e "\nExtracting files from $ARCHIVE_NAME in boot partition... be patient!"


### PR DESCRIPTION
There is a file called 'overlay_map.dtb' in /boot/overlays. If it's deleted, whenever we use line 'dtoverlay=vc4-kms-v3d' in config.txt, the bootloader will load 'vc4-kms-v3d' exactly as it is. But if overlay_map.dtb exists, and booting on RPI4, it will actually use 'vc4-kms-v3d-pi4'.
There are 2 solutions to fix the problem (no video output after adi_update_boot.sh is run):
1. Keep overlay_map.dtb and 'dtoverlay=vc4-kms-v3d' in config.txt
2. No overlay_map.dtb and, after loading 'dtoverlay=vc4-kms-v3d' (that works for RPI 2 and 3, load the pi4 specific one if booting on RPI4, like:
 ```
   [pi4]
  dtoverlay=vc4-kms-v3d-pi4
```
This PR implements the  first one.