### PR TITLE
Update network manager service

### DIFF
--- a/enable_dhcp.sh
+++ b/enable_dhcp.sh
@@ -34,5 +34,5 @@ else
 	# enable DHCP via NetworkManager (assumes the config file hasn't been touched much)
 	sed -i 's/^managed=true/managed=false/' /etc/NetworkManager/NetworkManager.conf
 
-	service network-manager restart
+	service NetworkManager restart
 fi

--- a/enable_static_ip.sh
+++ b/enable_static_ip.sh
@@ -45,5 +45,5 @@ else
 		netmask 255.255.255.0
 	EOF
 
-	service network-manager restart
+	service NetworkManager restart
 fi


### PR DESCRIPTION
Starting with Debian 12, network manager service changed it's name to 'NetworkManager'. 
enable_dhcp.sh: change 'network-manager' to 'NetworkManager' 
enable_static_ip.sh: change 'network-manager' to 'NetworkManager'