### PR TITLE
Makefile: remove daemon-reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ install:
 
 	install -D -m 0644 ./lightdm_timeout.conf /etc/systemd/system/lightdm.service.d/timeout.conf
 
-	systemctl daemon-reload
 	systemctl enable adi-power.service
 
 	/bin/sh usb-gadget-service/install_gt.sh


### PR DESCRIPTION
'make' command is run at built time, so there is no need to reload systemd manager configuration. 
'systemctl daemon-reload' is only needed at boot time to reload services without rebooting.