### PR TITLE
adi_update_tools.sh: Fix colorimeter dependency

### DIFF
--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -42,7 +42,7 @@ BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/main \
 	jesd-eye-scan-gtk:origin/main \
 	diagnostic_report:origin/main \
 	wiki-scripts:origin/main \
-	colorimeter:origin/main"
+	colorimeter:origin/2023_R2"
 
 BUILDS_2021_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R1 \


### PR DESCRIPTION
The main branch of colorimeter was updated to work with a newer version of Python(>3.11) in analogdevicesinc/colorimeter#7. Update `adi_update_tools.sh` to use 2023_R2 branch of colorimeter.