### PR TITLE
Add Jupiter SDR specific scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ install:
 
 	install -D -m 0644 ./lightdm_timeout.conf /etc/systemd/system/lightdm.service.d/timeout.conf
 
+	install -D -m 0644 ./jupiter_scripts/fan-control.service /etc/systemd/system/fan-control.service
+	install -D -m 0744 ./jupiter_scripts/fan-control /usr/bin/fan-control
+
 	systemctl daemon-reload
 	systemctl enable adi-power.service
+	systemctl enable fan-control.service
 
 	/bin/sh usb-gadget-service/install_gt.sh

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ install:
 	install -D -m 0644 ./jupiter_scripts/fan-control.service /etc/systemd/system/fan-control.service
 	install -D -m 0744 ./jupiter_scripts/fan-control /usr/bin/fan-control
 
+	install -D -m 0644 ./fix-display-port.service /etc/systemd/system/fix-display-port.service
+
 	systemctl daemon-reload
 	systemctl enable adi-power.service
 	systemctl enable fan-control.service
+	systemctl enable fix-display-port.service
 
 	/bin/sh usb-gadget-service/install_gt.sh

--- a/fix-display-port.service
+++ b/fix-display-port.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Fix DP audio and X11 for Jupiter
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
+
+[Install]
+WantedBy=multi-user.target

--- a/fix_DP_audio.sh
+++ b/fix_DP_audio.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+	# modify audio default sampling rate
+	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf
+fi

--- a/fix_x11.sh
+++ b/fix_x11.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
-grep -qi -e "ZCU102" -e "ADRV9009-ZU" /sys/firmware/devicetree/base/model && \
-printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" > /etc/X11/xorg.conf || \
-rm  /etc/X11/xorg.conf
+if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+	# create X11 xorg.conf
+	printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" \
+		> /etc/X11/xorg.conf \
+		|| rm  /etc/X11/xorg.conf
+
+	# delete xorg.conf created by enable_dummy_display if exists
+	rm -f /usr/share/X11/xorg.conf.d/xorg.conf
+fi

--- a/jupiter_scripts/fan-control
+++ b/jupiter_scripts/fan-control
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+GPIO_CHIP=334
+FAN_CTL=145
+USER_LED=14
+SLEEP_INTERVAL=1
+
+TEMP_LOW=73000
+TEMP_HIGH=78000
+TEMP_POWEROFF=80000
+
+gpio_export() {
+  if [ ! -d /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL) ]; then
+    echo $(expr $GPIO_CHIP + $FAN_CTL) > /sys/class/gpio/export
+    echo "out" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL)/direction
+    echo $(expr $GPIO_CHIP + $USER_LED) > /sys/class/gpio/export
+    echo "out" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/direction
+  fi
+}
+
+fan_low() {
+  echo "0" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL)/value
+}
+
+fan_high() {
+  echo "1" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL)/value
+}
+
+led_toggle() {
+  if [ $(cat /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/value) -eq "1" ]; then
+    echo "0" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/value
+  else
+    echo "1" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/value
+  fi
+}
+
+temp() {
+  echo $(iio_attr -c adrv9002-phy temp0 input)
+}
+
+last_five=()
+
+daemon() {
+  while :; do
+    led_toggle
+    current_temp=$(temp)
+
+    last_five=("${last_five[@]:1}")
+    last_five+=("$current_temp")
+
+    average=0
+    for i in ${last_five[@]}; do
+      let average+=$i
+    done
+    average=$(expr $average / 5)
+
+    if [[ $average -ge $TEMP_POWEROFF ]]; then
+      poweroff
+    fi
+
+    if [[ $average -le $TEMP_LOW ]]; then
+      fan_low
+    fi
+    if [[ $average -ge $TEMP_HIGH ]]; then
+      fan_high
+    fi
+
+    sleep $SLEEP_INTERVAL
+  done
+}
+
+last_five=()
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+
+gpio_export
+
+daemon

--- a/jupiter_scripts/fan-control.service
+++ b/jupiter_scripts/fan-control.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=fan-control
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'grep -i -e "Jupiter SDR" /sys/firmware/devicetree/base/model && /usr/bin/fan-control'
+
+[Install]
+WantedBy=multi-user.target

--- a/jupiter_scripts/fix-display-port.service
+++ b/jupiter_scripts/fix-display-port.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Fix DP audio and X11 for Jupiter
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
There are 2 new files for Jupiter:
  - 'fan-control.service' 
  - 'fan-control' (sh script)
I have added them in /jupiter_scripts and copied on desired paths during 'make install'.
There is a condition to start the service only if there is detected "Jupiter SDR"  ( from "/sys/firmware/devicetree/base/model"). 

The second big change is on fix_x11.sh:
  - extended condition to cover Jupiter case
  - delete file created by enable_dummy_display, if exists

The third big change is the fix for DP audio codec
  - fix DP audio sampling rate (to get rid of dmesg errors)
  - have an oneshot service that fix DP (audio and video) 