### PR TITLE
adrv9002 frequency hopping test script

### DIFF
--- a/test_adrv9002_fh.sh
+++ b/test_adrv9002_fh.sh
@@ -290,7 +290,7 @@ do_dev_init() {
 	else
 		[[ ${fh} == 0 ]] && error "Frequency hopping not enabled and profile not given..."
 		info "Initializing the device..."
-		iio_attr -D ${dev_name} initialize 1 1>/dev/null
+		iio_attr -D ${dev_name} initialize 1 >/dev/null 2>&1
 	fi
 
 	return 0


### PR DESCRIPTION
With the latest support in [adrv9002](https://github.com/analogdevicesinc/linux/pull/2582), we can now control the enable pins directly in the driver and that could break this script in case the devicetree sets thos GPIOs (which we want to do by default). Hence, fix it by assuming that we can control ensm_mode in case we can't export the GPIO.

On top it, we're also adding support for the Jupiter SDR.