### PR TITLE
Update network scripts

### DIFF
--- a/enable_dhcp.sh
+++ b/enable_dhcp.sh
@@ -34,5 +34,5 @@ else
 	# enable DHCP via NetworkManager (assumes the config file hasn't been touched much)
 	sed -i 's/^managed=true/managed=false/' /etc/NetworkManager/NetworkManager.conf
 
-	service NetworkManager restart
+	systemctl restart NetworkManager
 fi

--- a/enable_dhcp.sh
+++ b/enable_dhcp.sh
@@ -35,4 +35,5 @@ else
 	sed -i 's/^managed=true/managed=false/' /etc/NetworkManager/NetworkManager.conf
 
 	systemctl restart NetworkManager
+	systemctl restart networking
 fi

--- a/enable_static_ip.sh
+++ b/enable_static_ip.sh
@@ -46,4 +46,5 @@ else
 	EOF
 
 	systemctl restart NetworkManager
+	systemctl restart networking
 fi

--- a/enable_static_ip.sh
+++ b/enable_static_ip.sh
@@ -45,5 +45,5 @@ else
 		netmask 255.255.255.0
 	EOF
 
-	service NetworkManager restart
+	systemctl restart NetworkManager
 fi


### PR DESCRIPTION
Replace legacy command 'service' with 'systemctl'. The second one is more suitable for systemd-based systems (modern Linux distributions).
Restart the networking service after running these scripts. The networking service is responsible for reloading information from the '/etc/network/interfaces' file, which is overwritten by both scripts.