### PR TITLE
Remove fix service from jupiter directory

### DIFF
--- a/jupiter_scripts/fix-display-port.service
+++ b/jupiter_scripts/fix-display-port.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Fix DP audio and X11 for Jupiter
-
-[Service]
-Type=oneshot
-ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
Remove this service after copying it to the main directory since it is not a jupiter specific service.