### PR TITLE
fix_DP_audio: suppress sed exit code

### DIFF
--- a/fix_DP_audio.sh
+++ b/fix_DP_audio.sh
@@ -2,5 +2,5 @@
 
 if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
 	# modify audio default sampling rate
-	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf
+	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf 2>/dev/null || true
 fi


### PR DESCRIPTION
Suppress sed exit code and errors so that the script will run with success even if the file does not exist.