### PR TITLE
usb_otg.sh: fix for zynqmp

### DIFF
--- a/usb_otg.sh
+++ b/usb_otg.sh
@@ -28,7 +28,7 @@ check_platform() {
 		fdtget -p /boot/devicetree.dtb /axi > /dev/null 2>&1 && USB="/axi/usb@e0002000" || USB="/amba/usb@e0002000"
 		DTB="/boot/devicetree.dtb"
 	elif $(is_compatible "xlnx,zynqmp"); then
-		fdtget -p /boot/devicetree.dtb /axi > /dev/null 2>&1 && USB="/axi/usb0@ff9d0000/dwc3@fe200000" || USB="/amba/usb0@ff9d0000/dwc3@fe200000"
+		fdtget -p /boot/system.dtb /axi > /dev/null 2>&1 && USB="/axi/usb@ff9d0000/usb@fe200000" || USB="/amba/usb@ff9d0000/usb@fe200000"
 		DTB="/boot/system.dtb"
 	elif $(is_compatible "altr,socfpga-cyclone5"); then
 		USB="/soc/usb@ffb40000"


### PR DESCRIPTION
The usb_otg.sh script was trying to read the node 'axi' from 
/boot/devicetree.dtb which didn't exists. Replace it with /boot/system.dtb
Fix also value of 'USB' variable, conform with the nodes from zynqmp.dtsi.

This change does not affect Jupiter 'device mode', since Jupiter has usb set on otg/device by default in DTS.
But we'll get rid of FDT_ERR_NOTFOUND error that appears when the  script is run on zynqmp platforms.

Signed-off-by: Stefan Raus <Stefan.Raus@analog.com>
(cherry picked from commit da645c0575c95cd706ca5b124be71d147f141e25)