### PR TITLE
fix_x11, fix_DP_audio: fix 'if' statement

### DIFF
--- a/fix_DP_audio.sh
+++ b/fix_DP_audio.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+if grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model; then
 	# modify audio default sampling rate
 	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf 2>/dev/null || true
 fi

--- a/fix_x11.sh
+++ b/fix_x11.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+if grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model; then
 	# create X11 xorg.conf
 	printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" \
 		> /etc/X11/xorg.conf \


### PR DESCRIPTION
In 'if' statement, 'grep' always returned exit code to enter the first branch, no matter the contents of the checked file. Fixed that by removing the evaluation of the conditional expressions ( '[]' ).