### PR TITLE
Fix x11: fix 'if' statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ install:
 
 	install -D -m 0644 ./lightdm_timeout.conf /etc/systemd/system/lightdm.service.d/timeout.conf
 
+	install -D -m 0644 ./jupiter_scripts/fan-control.service /etc/systemd/system/fan-control.service
+	install -D -m 0744 ./jupiter_scripts/fan-control /usr/bin/fan-control
+
 	systemctl daemon-reload
 	systemctl enable adi-power.service
+	systemctl enable fan-control.service
 
 	/bin/sh usb-gadget-service/install_gt.sh

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ install:
 	install -D -m 0644 ./jupiter_scripts/fan-control.service /etc/systemd/system/fan-control.service
 	install -D -m 0744 ./jupiter_scripts/fan-control /usr/bin/fan-control
 
+	install -D -m 0644 ./fix-display-port.service /etc/systemd/system/fix-display-port.service
+
 	systemctl daemon-reload
 	systemctl enable adi-power.service
 	systemctl enable fan-control.service
+	systemctl enable fix-display-port.service
 
 	/bin/sh usb-gadget-service/install_gt.sh

--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -536,7 +536,8 @@ while true
         ### Remove boot partition
         echo "Removing boot files from /boot..."
         cd "$FAT_MOUNT" || exit 1
-        rm -rf !($default_files)
+        rm -f !($default_files)
+        rm -r ./overlays/*.dtbo
         cd - 2>&1 >/dev/null
         ### Extract new files
         echo -e "\nExtracting files from $ARCHIVE_NAME in boot partition... be patient!"

--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -3,7 +3,7 @@ shopt -s extglob # activate extended pattern matching
 
 ### Set global variables
 REPO="linux_image_ADI-scripts"
-BRANCH="origin/master"
+BRANCH="origin/main"
 SERVER="http://swdownloads.analog.com"
 SPATH="cse/boot_partition_files"
 RPI_SPATH="cse/linux_rpi"
@@ -12,7 +12,7 @@ ARCHIVE_NAME="latest_boot_partition.tar.gz"
 # Whenever 'latest' and 'previous' are updated, need to update also conditions from next if
 LATEST_RELEASE="2021_r2"
 RELEASE=$LATEST_RELEASE
-LATEST_RPI_BRANCH="rpi-5.10.y"
+LATEST_RPI_BRANCH="rpi-5.15.y"
 RPI_BRANCH=$LATEST_RPI_BRANCH
 FILE="latest_boot.txt"
 RPI_FILE="rpi_archives_properties.txt"
@@ -20,13 +20,13 @@ RPI_FILE="rpi_archives_properties.txt"
 ### Allow selective builds. By default use the latest release
 if [ "$1" = "help" -o "$1" = "-h" ]; then
   echo "This script can be called with a parameter to select the release:"
-  echo "  There can be used 'dev'(or 'master') for boot files from master,"
+  echo "  There can be used 'dev'(or 'master' or 'main') for boot files from main,"
   echo "  or a specific release (for example '2019_R2') for specific boot files."
   echo "  By default will use latest released version (right now being $LATEST_RELEASE)."
   exit 0
-elif [ "$1" = "dev"  -o "$1" = "master" ]; then
-  RELEASE="master"
-  RPI_BRANCH="rpi-5.10.y"
+elif [ "$1" = "dev"  -o "$1" = "master" -o "$1" =  "main" ]; then
+  RELEASE="main"
+  RPI_BRANCH="rpi-6.1.y"
 elif [ "$1" = "2019_R1" -o "$1" = "2019_r1" ]; then
   RELEASE="2019_r1"
   RPI_BRANCH="rpi-4.9.y"
@@ -157,7 +157,7 @@ new_release=$(echo $new_release | tr '[:upper:]' '[:lower:]')
 if [ "$current_release" != "$new_release" ]; then
   # Check if files fit on boot partition (for older release including 2019-R2 there is 1 GB, newer ones have 2 GB)
   boot_part_size=$(df -k $FAT_MOUNT | awk '/[0-9]%/{print $(NF-4)}' | sed 's/G//')
-  if [[ "$new_release" =~ *"2021_r1"* ]] || [[ "$new_release" =~ *"2021_r2"* ]] || [[ "$new_release" =~ *"master"* ]]; then
+  if [[ "$new_release" =~ *"2021_r1"* ]] || [[ "$new_release" =~ *"2021_r2"* ]] || [[ "$new_release" =~ *"main"* ]]; then
     if [[ $boot_part_size -lt 1250000 ]]; then
       echo -e "\nWarning! You want to update boot files from a newer release: $new_release (current release: $current_release)"
       echo "But newer releases have the size of boot files more than 1 GB (the size of boot partition used in older releases),"
@@ -332,7 +332,7 @@ restoring_boot_bin()
     fi
   elif [[ "$1" == *"arria10"* ]]; then
     echo -e "\nRestoring socfpga_arria10_socdk.rbf/fit_spl_fpga.itb..."
-    # Restore config depending on release, in master and starting with 2021_R1
+    # Restore config depending on release, in main and starting with 2021_R1
     # there is a different boot flow (starting with Quartus Pro 20.1)
     if [ "$new_release" == "2019_r1" -o "$new_release" == "2019_r2" ]; then
       if [ -e $1/socfpga_arria10_socdk.rbf ]; then
@@ -474,13 +474,13 @@ restoring_extra_files()
 {
   if [[ "$1" == *"cyclone5"* ]]; then
     restoring_u-boot_file "$1/u-boot.scr"
-    # Restore config depending on release, in master and starting with 2021_R1
+    # Restore config depending on release, in main and starting with 2021_R1
     # there is a different boot flow (starting with Quartus Pro 20.1)
     if [ "$new_release" != "2019_r1" ] && [ "$new_release" != "2019_r2" ]; then
       restoring_extlinux $1
     fi
   elif [[ "$1" == *"arria10"* ]]; then
-    # Restore config depending on release, in master and starting with 2021_R1
+    # Restore config depending on release, in main and starting with 2021_R1
     # there is a different boot flow (starting with Quartus Pro 20.1)
     if [ "$new_release" != "2019_r1" ] && [ "$new_release" != "2019_r2" ]; then
       restoring_u-boot_file "$1/u-boot.img"

--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -10,7 +10,7 @@ RPI_SPATH="cse/linux_rpi"
 ARCHIVE_NAME="latest_boot_partition.tar.gz"
 
 # Whenever 'latest' and 'previous' are updated, need to update also conditions from next if
-LATEST_RELEASE="2021_r2"
+LATEST_RELEASE="2022_r2"
 RELEASE=$LATEST_RELEASE
 LATEST_RPI_BRANCH="rpi-5.15.y"
 RPI_BRANCH=$LATEST_RPI_BRANCH
@@ -39,6 +39,9 @@ elif [ "$1" = "2021_R1" -o "$1" = "2021_r1" ]; then
 elif [ "$1" = "2021_R2" -o "$1" = "2021_r2" ]; then
   RELEASE="2021_r2"
   RPI_BRANCH="rpi-5.10.y"
+elif [ "$1" = "2022_R2" -o "$1" = "2022_r2" ]; then
+  RELEASE="2022_r2"
+  RPI_BRANCH="rpi-5.15.y"
 fi
 
 ### Verify if current script is latest version

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -98,6 +98,19 @@ BUILDS_2021_R2="linux_image_ADI-scripts:origin/main \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R2"
 
+BUILDS_2022_R2="linux_image_ADI-scripts:origin/main \
+	libiio:origin/2022_R2 \
+	libad9361-iio:origin/2022_R2 \
+	libad9166-iio:origin/2022_R2 \
+	iio-oscilloscope:origin/2022_R2\
+	fru_tools:origin/2022_R2 \
+	iio-fm-radio:origin/main \
+	wiki-scripts:origin/main \
+	jesd-eye-scan-gtk:origin/2022_R2 \
+	diagnostic_report:origin/main \
+	colorimeter:origin/2022_R2"
+
+
 # Define file where to save git info
 VERSION="/ADI_repos_git_info.txt"
 [ -f $VERSION ] && rm -rf $VERSION
@@ -268,6 +281,9 @@ then
 elif [[ "$1" = "2021_R2" ]] || [[ "$1" = "2021_r2" ]]
 then
   BUILDS=$BUILDS_2021_R2
+elif [[ "$1" = "2022_R2" ]] || [[ "$1" = "2022_r2" ]]
+then
+  BUILDS=$BUILDS_2022_R2
 elif [[ "$1" = "NEXT_STABLE" ]] || [[ "$1" = "next_stable" ]]
 then
   BUILDS=$BUILDS_NEXT_STABLE

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -21,47 +21,47 @@ md5_self=`md5sum $0`
 # repository:branch:make_target
 
 BUILDS_DEV="linux_image_ADI-scripts:origin/master \
-	libiio:origin/master \
-	libad9361-iio:origin/master \
-	libad9166-iio:origin/master \
-	iio-oscilloscope:origin/master \
-	fru_tools:origin/master \
-	iio-fm-radio:origin/master \
-	jesd-eye-scan-gtk:origin/master \
-	diagnostic_report:origin/master \
-	wiki-scripts:origin/master \
-	colorimeter:origin/master"
+	libiio:origin/main \
+	libad9361-iio:origin/main \
+	libad9166-iio:origin/main \
+	iio-oscilloscope:origin/main \
+	fru_tools:origin/main \
+	iio-fm-radio:origin/main \
+	jesd-eye-scan-gtk:origin/main \
+	diagnostic_report:origin/main \
+	wiki-scripts:origin/main \
+	colorimeter:origin/main"
 
 BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/master \
 	libiio:origin/next_stable \
 	libad9361-iio:origin/next_stable \
 	libad9166-iio:origin/next_stable \
 	iio-oscilloscope:origin/next_stable \
-	fru_tools:origin/master \
-	iio-fm-radio:origin/master \
-	jesd-eye-scan-gtk:origin/master \
-	diagnostic_report:origin/master \
-	wiki-scripts:origin/master \
-	colorimeter:origin/master"
+	fru_tools:origin/main \
+	iio-fm-radio:origin/main \
+	jesd-eye-scan-gtk:origin/main \
+	diagnostic_report:origin/main \
+	wiki-scripts:origin/main \
+	colorimeter:origin/main"
 
 BUILDS_2018_R2="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2018_R2 \
-	libad9361-iio:origin/master \
+	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2018_R2\
 	fru_tools:origin/2018_R2 \
 	iio-fm-radio:origin/2015_R2 \
 	jesd-eye-scan-gtk:origin/2018_R2 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2018_R2"
 
 BUILDS_2019_R1="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2019_R1 \
-	libad9361-iio:origin/master \
+	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2019_R1\
 	fru_tools:origin/2019_R1 \
 	iio-fm-radio:origin/2015_R2 \
 	jesd-eye-scan-gtk:origin/2019_R1 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R1"
 
 BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
@@ -71,31 +71,31 @@ BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
 	fru_tools:origin/2019_R2 \
 	iio-fm-radio:origin/2015_R2 \
 	jesd-eye-scan-gtk:origin/2019_R2 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R2"
 
 BUILDS_2021_R1="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2021_R1 \
 	libad9361-iio:origin/2021_R1 \
-	libad9166-iio:origin/master \
+	libad9166-iio:origin/main \
 	iio-oscilloscope:origin/2021_R1\
 	fru_tools:origin/2021_R1 \
-	iio-fm-radio:origin/master \
-	wiki-scripts:origin/master \
+	iio-fm-radio:origin/main \
+	wiki-scripts:origin/main \
 	jesd-eye-scan-gtk:origin/2021_R1 \
-	diagnostic_report:origin/master \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R1"
 
 BUILDS_2021_R2="linux_image_ADI-scripts:origin/master \
 	libiio:origin/2021_R2 \
 	libad9361-iio:origin/2021_R2 \
-	libad9166-iio:origin/master \
+	libad9166-iio:origin/main \
 	iio-oscilloscope:origin/2021_R2\
-	fru_tools:origin/master \
-	iio-fm-radio:origin/master \
-	wiki-scripts:origin/master \
-	jesd-eye-scan-gtk:origin/master \
-	diagnostic_report:origin/master \
+	fru_tools:origin/main \
+	iio-fm-radio:origin/main \
+	wiki-scripts:origin/main \
+	jesd-eye-scan-gtk:origin/main \
+	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R2"
 
 # Define file where to save git info
@@ -253,7 +253,7 @@ rfsom_box ()
 }
 
 # Allow selective builds by default build the latest release branches
-if [[ "$1" =~ "dev" ]] || [[ "$1" = "master" ]]
+if [[ "$1" =~ "dev" ]] || [[ "$1" = "main" ]]
 then
   BUILDS=$BUILDS_DEV
 elif [[ "$1" = "2019_R1" ]] || [[ "$1" = "2019_r1" ]]
@@ -284,11 +284,11 @@ do
   BRANCH=`echo $i | cut -s -d':' -f2`
   TARGET=`echo $i | cut -s -d':' -f3`
 
-# selective build without branch? use master
+# selective build without branch? use main
   if [ -z $BRANCH ]
   then
     echo HERE
-    BRANCH=origin/master
+    BRANCH=origin/main
     TARGET=""
   fi
 

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -44,36 +44,6 @@ BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/main \
 	wiki-scripts:origin/main \
 	colorimeter:origin/main"
 
-BUILDS_2018_R2="linux_image_ADI-scripts:origin/main \
-	libiio:origin/2018_R2 \
-	libad9361-iio:origin/main \
-	iio-oscilloscope:origin/2018_R2\
-	fru_tools:origin/2018_R2 \
-	iio-fm-radio:origin/2015_R2 \
-	jesd-eye-scan-gtk:origin/2018_R2 \
-	diagnostic_report:origin/main \
-	colorimeter:origin/2018_R2"
-
-BUILDS_2019_R1="linux_image_ADI-scripts:origin/main \
-	libiio:origin/2019_R1 \
-	libad9361-iio:origin/main \
-	iio-oscilloscope:origin/2019_R1\
-	fru_tools:origin/2019_R1 \
-	iio-fm-radio:origin/2015_R2 \
-	jesd-eye-scan-gtk:origin/2019_R1 \
-	diagnostic_report:origin/main \
-	colorimeter:origin/2019_R1"
-
-BUILDS_2019_R2="linux_image_ADI-scripts:origin/main \
-	libiio:origin/2019_R2 \
-	libad9361-iio:origin/2019_R2 \
-	iio-oscilloscope:origin/2019_R2\
-	fru_tools:origin/2019_R2 \
-	iio-fm-radio:origin/2015_R2 \
-	jesd-eye-scan-gtk:origin/2019_R2 \
-	diagnostic_report:origin/main \
-	colorimeter:origin/2019_R2"
-
 BUILDS_2021_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R1 \
 	libad9361-iio:origin/2021_R1 \
@@ -269,12 +239,12 @@ rfsom_box ()
 if [[ "$1" =~ "dev" ]] || [[ "$1" = "main" ]]
 then
   BUILDS=$BUILDS_DEV
-elif [[ "$1" = "2019_R1" ]] || [[ "$1" = "2019_r1" ]]
+elif [[ "$1" = "2018_R2" ]] || [[ "$1" = "2018_r2" ]] || \
+     [[ "$1" = "2019_R1" ]] || [[ "$1" = "2019_r1" ]] || \
+     [[ "$1" = "2019_R2" ]] || [[ "$1" = "2019_r2" ]]
 then
-  BUILDS=$BUILDS_2019_R1
-elif [[ "$1" = "2019_R2" ]] || [[ "$1" = "2019_r2" ]]
-then
-  BUILDS=$BUILDS_2019_R2
+  echo "Only last two releases are supported for update."
+  exit 1
 elif [[ "$1" = "2021_R1" ]] || [[ "$1" = "2021_r1" ]]
 then
   BUILDS=$BUILDS_2021_R1

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -42,7 +42,7 @@ BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/main \
 	jesd-eye-scan-gtk:origin/main \
 	diagnostic_report:origin/main \
 	wiki-scripts:origin/main \
-	colorimeter:origin/main"
+	colorimeter:origin/2023_R2"
 
 BUILDS_2021_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R1 \

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -61,10 +61,10 @@ BUILDS_2021_R2="linux_image_ADI-scripts:origin/main \
 	libad9361-iio:origin/2021_R2 \
 	libad9166-iio:origin/main \
 	iio-oscilloscope:origin/2021_R2\
-	fru_tools:origin/main \
+	fru_tools:origin/2021_R2 \
 	iio-fm-radio:origin/main \
 	wiki-scripts:origin/main \
-	jesd-eye-scan-gtk:origin/main \
+	jesd-eye-scan-gtk:origin/2021_R2 \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R2"
 

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -20,7 +20,7 @@ md5_self=`md5sum $0`
 # scripts ...
 # repository:branch:make_target
 
-BUILDS_DEV="linux_image_ADI-scripts:origin/master \
+BUILDS_DEV="linux_image_ADI-scripts:origin/main \
 	libiio:origin/main \
 	libad9361-iio:origin/main \
 	libad9166-iio:origin/main \
@@ -32,7 +32,7 @@ BUILDS_DEV="linux_image_ADI-scripts:origin/master \
 	wiki-scripts:origin/main \
 	colorimeter:origin/main"
 
-BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/master \
+BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/main \
 	libiio:origin/next_stable \
 	libad9361-iio:origin/next_stable \
 	libad9166-iio:origin/next_stable \
@@ -44,7 +44,7 @@ BUILDS_NEXT_STABLE="linux_image_ADI-scripts:origin/master \
 	wiki-scripts:origin/main \
 	colorimeter:origin/main"
 
-BUILDS_2018_R2="linux_image_ADI-scripts:origin/master \
+BUILDS_2018_R2="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2018_R2 \
 	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2018_R2\
@@ -54,7 +54,7 @@ BUILDS_2018_R2="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2018_R2"
 
-BUILDS_2019_R1="linux_image_ADI-scripts:origin/master \
+BUILDS_2019_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2019_R1 \
 	libad9361-iio:origin/main \
 	iio-oscilloscope:origin/2019_R1\
@@ -64,7 +64,7 @@ BUILDS_2019_R1="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R1"
 
-BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
+BUILDS_2019_R2="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2019_R2 \
 	libad9361-iio:origin/2019_R2 \
 	iio-oscilloscope:origin/2019_R2\
@@ -74,7 +74,7 @@ BUILDS_2019_R2="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2019_R2"
 
-BUILDS_2021_R1="linux_image_ADI-scripts:origin/master \
+BUILDS_2021_R1="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R1 \
 	libad9361-iio:origin/2021_R1 \
 	libad9166-iio:origin/main \
@@ -86,7 +86,7 @@ BUILDS_2021_R1="linux_image_ADI-scripts:origin/master \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2021_R1"
 
-BUILDS_2021_R2="linux_image_ADI-scripts:origin/master \
+BUILDS_2021_R2="linux_image_ADI-scripts:origin/main \
 	libiio:origin/2021_R2 \
 	libad9361-iio:origin/2021_R2 \
 	libad9166-iio:origin/main \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,12 @@
 trigger:
 - master
 - main
+- kuiper2.0
 
 pr:
 - master
 - main
+- kuiper2.0
 
 pool:
   vmImage: ubuntu-latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,10 @@
 trigger:
 - master
+- main
 
 pr:
 - master
+- main
 
 pool:
   vmImage: ubuntu-latest

--- a/fix-display-port.service
+++ b/fix-display-port.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Fix DP audio and X11 for Jupiter
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
+
+[Install]
+WantedBy=multi-user.target

--- a/fix_DP_audio.sh
+++ b/fix_DP_audio.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+	# modify audio default sampling rate
+	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf
+fi

--- a/fix_DP_audio.sh
+++ b/fix_DP_audio.sh
@@ -2,5 +2,5 @@
 
 if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
 	# modify audio default sampling rate
-	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf
+	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf 2>/dev/null || true
 fi

--- a/fix_x11.sh
+++ b/fix_x11.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
-grep -qi -e "ZCU102" -e "ADRV9009-ZU" /sys/firmware/devicetree/base/model && \
-printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" > /etc/X11/xorg.conf || \
-rm  /etc/X11/xorg.conf
+if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+	# create X11 xorg.conf
+	printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" \
+		> /etc/X11/xorg.conf \
+		|| rm  /etc/X11/xorg.conf
+
+	# delete xorg.conf created by enable_dummy_display if exists
+	rm -f /usr/share/X11/xorg.conf.d/xorg.conf
+fi

--- a/fix_x11.sh
+++ b/fix_x11.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+if grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model; then
 	# create X11 xorg.conf
 	printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" \
 		> /etc/X11/xorg.conf \

--- a/jupiter_scripts/fan-control
+++ b/jupiter_scripts/fan-control
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+GPIO_CHIP=334
+FAN_CTL=145
+USER_LED=14
+SLEEP_INTERVAL=1
+
+TEMP_LOW=73000
+TEMP_HIGH=78000
+TEMP_POWEROFF=80000
+
+gpio_export() {
+  if [ ! -d /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL) ]; then
+    echo $(expr $GPIO_CHIP + $FAN_CTL) > /sys/class/gpio/export
+    echo "out" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL)/direction
+    echo $(expr $GPIO_CHIP + $USER_LED) > /sys/class/gpio/export
+    echo "out" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/direction
+  fi
+}
+
+fan_low() {
+  echo "0" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL)/value
+}
+
+fan_high() {
+  echo "1" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $FAN_CTL)/value
+}
+
+led_toggle() {
+  if [ $(cat /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/value) -eq "1" ]; then
+    echo "0" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/value
+  else
+    echo "1" > /sys/class/gpio/gpio$(expr $GPIO_CHIP + $USER_LED)/value
+  fi
+}
+
+temp() {
+  echo $(iio_attr -c adrv9002-phy temp0 input)
+}
+
+last_five=()
+
+daemon() {
+  while :; do
+    led_toggle
+    current_temp=$(temp)
+
+    last_five=("${last_five[@]:1}")
+    last_five+=("$current_temp")
+
+    average=0
+    for i in ${last_five[@]}; do
+      let average+=$i
+    done
+    average=$(expr $average / 5)
+
+    if [[ $average -ge $TEMP_POWEROFF ]]; then
+      poweroff
+    fi
+
+    if [[ $average -le $TEMP_LOW ]]; then
+      fan_low
+    fi
+    if [[ $average -ge $TEMP_HIGH ]]; then
+      fan_high
+    fi
+
+    sleep $SLEEP_INTERVAL
+  done
+}
+
+last_five=()
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+last_five+=("$(temp)")
+
+gpio_export
+
+daemon

--- a/jupiter_scripts/fan-control.service
+++ b/jupiter_scripts/fan-control.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=fan-control
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'grep -i -e "Jupiter SDR" /sys/firmware/devicetree/base/model && /usr/bin/fan-control'
+
+[Install]
+WantedBy=multi-user.target

--- a/jupiter_scripts/fix-display-port.service
+++ b/jupiter_scripts/fix-display-port.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Fix DP audio and X11 for Jupiter
-
-[Service]
-Type=oneshot
-ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
-
-[Install]
-WantedBy=multi-user.target

--- a/jupiter_scripts/fix-display-port.service
+++ b/jupiter_scripts/fix-display-port.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Fix DP audio and X11 for Jupiter
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
+
+[Install]
+WantedBy=multi-user.target

--- a/usb_otg.sh
+++ b/usb_otg.sh
@@ -28,7 +28,7 @@ check_platform() {
 		fdtget -p /boot/devicetree.dtb /axi > /dev/null 2>&1 && USB="/axi/usb@e0002000" || USB="/amba/usb@e0002000"
 		DTB="/boot/devicetree.dtb"
 	elif $(is_compatible "xlnx,zynqmp"); then
-		fdtget -p /boot/devicetree.dtb /axi > /dev/null 2>&1 && USB="/axi/usb0@ff9d0000/dwc3@fe200000" || USB="/amba/usb0@ff9d0000/dwc3@fe200000"
+		fdtget -p /boot/system.dtb /axi > /dev/null 2>&1 && USB="/axi/usb@ff9d0000/usb@fe200000" || USB="/amba/usb@ff9d0000/usb@fe200000"
 		DTB="/boot/system.dtb"
 	elif $(is_compatible "altr,socfpga-cyclone5"); then
 		USB="/soc/usb@ffb40000"


### PR DESCRIPTION
In 'if' statement, 'grep' always returned exit code to enter the first branch, no matter the contents of the checked file. Fixed that by removing the evaluation of the conditional expressions ( '[]' ).