### PR TITLE
Fix 'if' statement in 'fix_x11.sh' and add a fix for DP audio codec

### DIFF
--- a/fix-display-port.service
+++ b/fix-display-port.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=Fix X11 for Display Port
+Description=Fix DP audio and X11
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash "fix_x11.sh"
+ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
 
 [Install]
 WantedBy=multi-user.target

--- a/fix_DP_audio.sh
+++ b/fix_DP_audio.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model; then
+	# modify audio default sampling rate
+	sed -i '/default-sample-rate/c\default-sample-rate = 48000' /etc/pulse/daemon.conf 2>/dev/null || true
+fi

--- a/fix_x11.sh
+++ b/fix_x11.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-if [ ! $(grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model) ]; then
+if grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model; then
 	# create X11 xorg.conf
 	printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" \
-		> /etc/X11/xorg.conf \
-		|| rm  /etc/X11/xorg.conf
-
-	# delete xorg.conf created by enable_dummy_display if exists
-	rm -f /usr/share/X11/xorg.conf.d/xorg.conf
+		> /etc/X11/xorg.conf
+else
+	rm -f /etc/X11/xorg.conf
 fi


### PR DESCRIPTION
In 'if' statement, 'grep' always returned exit code to enter the first branch, no matter the contents of the checked file. Fixed that by removing the evaluation of the conditional expressions ( '[]' ).
Fix error "zynqmp_dp_snd_codec0: Failed to get required clock freq" by setting default sample rate to 48000.
Create fix-display-port.service that runs fix_x11.sh and fix_DP_audio.sh at boot.