### PR TITLE
fix_x11: remove xorg.conf only for non-DP platforms

### DIFF
--- a/fix_x11.sh
+++ b/fix_x11.sh
@@ -3,9 +3,10 @@
 if grep -qi -e "ZCU102" -e "ADRV9009-ZU" -e "Jupiter SDR" /sys/firmware/devicetree/base/model; then
 	# create X11 xorg.conf
 	printf "Section \"Device\"\n  Identifier \"myfb\"\n  Driver \"fbdev\"\n  Option \"fbdev\" \"/dev/fb0\"\nEndSection\n" \
-		> /etc/X11/xorg.conf \
-		|| rm  /etc/X11/xorg.conf
+		> /etc/X11/xorg.conf
 
 	# delete xorg.conf created by enable_dummy_display if exists
 	rm -f /usr/share/X11/xorg.conf.d/xorg.conf
+else
+	rm -f /etc/X11/xorg.conf
 fi


### PR DESCRIPTION
Create /etc/X11/xorg.conf file if there is detected a platform with Display Port and remove it if there is detected a non-DP one.
The previous implementation doesn't make sense, since will try to delete the file that couldn't be created.