### PR TITLE
adi_update_boot/tools: add 2023_r2 branches

### DIFF
--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -36,6 +36,9 @@ elif [ "$1" = "2021_R2" -o "$1" = "2021_r2" ]; then
 elif [ "$1" = "2022_R2" -o "$1" = "2022_r2" ]; then
   RELEASE="2022_r2"
   RPI_BRANCH="rpi-5.15.y"
+elif [ "$1" = "2023_R2" -o "$1" = "2023_r2" ]; then
+  RELEASE="2023_r2"
+  RPI_BRANCH="rpi-6.1.y"
 fi
 
 ### Verify if current script is latest version

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -80,6 +80,17 @@ BUILDS_2022_R2="linux_image_ADI-scripts:origin/main \
 	diagnostic_report:origin/main \
 	colorimeter:origin/2022_R2"
 
+BUILDS_2023_R2="linux_image_ADI-scripts:origin/main \
+	libiio:origin/2023_R2 \
+	libad9361-iio:origin/2023_R2 \
+	libad9166-iio:origin/2023_R2 \
+	iio-oscilloscope:origin/2023_R2\
+	fru_tools:origin/2023_R2 \
+	iio-fm-radio:origin/main \
+	wiki-scripts:origin/main \
+	jesd-eye-scan-gtk:origin/2023_R2 \
+	diagnostic_report:origin/main \
+	colorimeter:origin/2023_R2"
 
 # Define file where to save git info
 VERSION="/ADI_repos_git_info.txt"
@@ -254,6 +265,9 @@ then
 elif [[ "$1" = "2022_R2" ]] || [[ "$1" = "2022_r2" ]]
 then
   BUILDS=$BUILDS_2022_R2
+elif [[ "$1" = "2023_R2" ]] || [[ "$1" = "2023_r2" ]]
+then
+  BUILDS=$BUILDS_2023_R2
 elif [[ "$1" = "NEXT_STABLE" ]] || [[ "$1" = "next_stable" ]]
 then
   BUILDS=$BUILDS_NEXT_STABLE
@@ -261,7 +275,7 @@ elif [ -n "$1" ]
 then
   BUILDS=$1
 else
-  BUILDS=$BUILDS_2021_R2
+  BUILDS=$BUILDS_2022_R2
 fi
 
 for i in $BUILDS


### PR DESCRIPTION
Add 2023_r2 branches also in master, in order to have them also in older images.
Default branch was switched to 'main' during 2022_r2 release, so this change will allow people that use older images (where default is 'master') to update tools and boot files to 2023_r2.

Signed-off-by: Stefan Raus <Stefan.Raus@analog.com>
(cherry picked from commit 8e0e97781da02c1d79b47cde40788b5d7de0b38b)