### PR TITLE
adi_update_boot/tools:set default param to 2023_r2

### DIFF
--- a/adi_update_boot.sh
+++ b/adi_update_boot.sh
@@ -10,9 +10,9 @@ RPI_SPATH="cse/linux_rpi"
 ARCHIVE_NAME="latest_boot_partition.tar.gz"
 
 # Whenever 'latest' and 'previous' are updated, need to update also conditions from next if
-LATEST_RELEASE="2022_r2"
+LATEST_RELEASE="2023_r2"
 RELEASE=$LATEST_RELEASE
-LATEST_RPI_BRANCH="rpi-5.15.y"
+LATEST_RPI_BRANCH="rpi-6.1.y"
 RPI_BRANCH=$LATEST_RPI_BRANCH
 FILE="latest_boot.txt"
 RPI_FILE="rpi_archives_properties.txt"

--- a/adi_update_tools.sh
+++ b/adi_update_tools.sh
@@ -275,7 +275,7 @@ elif [ -n "$1" ]
 then
   BUILDS=$1
 else
-  BUILDS=$BUILDS_2022_R2
+  BUILDS=$BUILDS_2023_R2
 fi
 
 for i in $BUILDS


### PR DESCRIPTION
The scripts "adi_update_boot.sh" and "adi_update_tools.sh" got tested with parameter '2023_r2' and they work fine.
Set default parameter value to "2023_r2".