### PR TITLE
usb-gadget-service/scripts: handle SDP/ARDZ EEPROMs

### DIFF
--- a/usb-gadget-service/install_gt.sh
+++ b/usb-gadget-service/install_gt.sh
@@ -55,6 +55,7 @@ install -D -m 0644 schemes/iio_ncm.scheme /usr/local/etc/gt/adi/
 install -D -m 0644 schemes/iio_acmx2_rndis.scheme /usr/local/etc/gt/adi/
 
 install -D -m 0744 scripts/iiod_context.sh /usr/local/bin/
+install -D -m 0744 scripts/read-sdp-eeprom /usr/local/bin/
 install -D -m 0744 scripts/usb_gadget.sh /usr/local/bin/
 
 install -D -m 0644 udev/99-udc.rules /etc/udev/rules.d/

--- a/usb-gadget-service/scripts/iiod_context.sh
+++ b/usb-gadget-service/scripts/iiod_context.sh
@@ -59,6 +59,18 @@ if [ "$?" = "0" ] ; then
 	done
 fi
 
+# If this is a SDP/ARDZ board, capture the data
+if [ -z "$BOARD" ]; then
+	for f in $(find /sys/ -name eeprom); do
+		sdp_board_info=$(read-sdp-eeprom $f 2>/dev/null)
+		if [ -n "$sdp_board_info" ]; then
+			BOARD=$(echo "$sdp_board_info" | grep "^name:" | cut -d':' -f2 | sed 's/^[[:space:]]*//')
+			SERIAL=$(echo "$sdp_board_info" | grep "^id:" | cut -d':' -f2 | sed 's/^[[:space:]]*//')
+			VENDOR="Analog Devices"
+		fi
+	done
+fi
+
 # If you are a Raspberry Pi HAT, add that
 if [ -d "/sys/firmware/devicetree/base/hat" ] ; then
 	BOARD=$(sanitize "/sys/firmware/devicetree/base/hat/product_id")

--- a/usb-gadget-service/scripts/read-sdp-eeprom
+++ b/usb-gadget-service/scripts/read-sdp-eeprom
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""
+ADI SDP hardware board information read and parse module
+
+Based on:
+https://github.com/analogdevicesinc/precision-converters-library/blob/3cd2cd98f9c2acce9d8cbd695239fd613003074f/board_info/board_info.c
+"""
+
+import struct
+import sys
+
+DATA_MAX_LEN = 256
+LEGACY_BOARD_ID_LEN = 18
+HEADER_LEN = 10
+HEADER_ID_LEN = 6
+HEADER_DATA_LEN_INDEX = 8
+RECORD_FOOTER_LEN = 3
+
+try:
+    eeprom_path = sys.argv[1]
+except IndexError:
+    print(f"usage: {sys.argv[0]} <eeprom path>", file=sys.stderr)
+    exit(1)
+
+debug = "--debug" in sys.argv
+
+with open(eeprom_path, "rb") as f:
+    header = f.read(HEADER_LEN)
+
+    if header[:HEADER_ID_LEN] != b"ADISDP":
+        print(f"Bad header '{header}'", file=sys.stderr)
+        exit(1)
+
+    data_len = header[HEADER_DATA_LEN_INDEX] - HEADER_LEN
+    
+    if data_len > DATA_MAX_LEN:
+        print(f"Unexpected data len: {data_len}", file=sys.stderr)
+        exit(1)
+
+    data = f.read(data_len)
+
+    if debug:
+        print(f"data: {data}")
+
+board = {}
+index = 0
+
+while index < data_len:
+    rec_type, rec_len = struct.unpack_from("<BH", data, index)
+    rec_data = data[index + 3 : index + rec_len]
+    index += rec_len
+
+    if debug:
+        print(f"type: 0x{rec_type:02X}")
+        print(rec_data)
+
+    if rec_type == 0x01:
+        # Hardware ID for legacy EVBs
+        board["id"] = f"{rec_data[1]:02X}{rec_data[0]:02X}{rec_data[3]:02X}{rec_data[2]:02X}{rec_data[7]:02X}{rec_data[6]:02X}{rec_data[5]:02X}{rec_data[4]:02X}"
+    elif rec_type == 0x02:
+        # EVB name info
+        board["name"] = rec_data.decode()
+    elif rec_type in [0x03, 0x04, 0x05, 0x0D, 0x0F]:
+        # Valid but unused record types
+        pass
+    elif rec_type == 0x0E:
+        # SAP code ID
+        board["id"] = rec_data.decode()
+    else:
+        print(f"Invalid record: 0x{rec_type:02X}", file=sys.stderr)
+        exit(1)
+
+for k, v in board.items():
+    print(f"{k}: {v}")
+


### PR DESCRIPTION
Handle reading the EEPROM on SDP/ARDZ boards. These use a different data format from the FMC boards and need a different parser. There doesn't seem to be a general purpose tool for this, so add a new Python script here for that and use that in the iiod_context.sh script to read the EEPROM and update the /etc/libiio.ini file.

This way, libiio will be able to pick up the hw_mezzanine and hw_serial