### PR TITLE
enable_static_ip, enable_dhcp: remove dhcpcd

### DIFF
--- a/enable_dhcp.sh
+++ b/enable_dhcp.sh
@@ -16,24 +16,17 @@ if [[ ${UID} -ne 0 ]]; then
 	exit 1
 fi
 
-if grep -qi kuiper "/etc/os-release"; then
-	cat <<-EOF > /etc/dhcpcd.conf
-		hostname
-	EOF
-	systemctl daemon-reload
-	systemctl restart dhcpcd.service
-else
-	echo "Re-enabling DHCP via NetworkManager for all network interfaces"
 
-	cat <<-EOF > /etc/network/interfaces
-		# interfaces(5) file used by ifup(8) and ifdown(8)
-		# Include files from /etc/network/interfaces.d:
-		source-directory /etc/network/interfaces.d
-	EOF
+echo "Re-enabling DHCP via NetworkManager for all network interfaces"
 
-	# enable DHCP via NetworkManager (assumes the config file hasn't been touched much)
-	sed -i 's/^managed=true/managed=false/' /etc/NetworkManager/NetworkManager.conf
+cat <<-EOF > /etc/network/interfaces
+	# interfaces(5) file used by ifup(8) and ifdown(8)
+	# Include files from /etc/network/interfaces.d:
+	source-directory /etc/network/interfaces.d
+EOF
 
-	systemctl restart NetworkManager
-	systemctl restart networking
-fi
+# enable DHCP via NetworkManager (assumes the config file hasn't been touched much)
+sed -i 's/^managed=true/managed=false/' /etc/NetworkManager/NetworkManager.conf
+
+systemctl restart NetworkManager
+systemctl restart networking

--- a/enable_static_ip.sh
+++ b/enable_static_ip.sh
@@ -23,28 +23,19 @@ fi
 
 echo "Enabling the static IP address ${IP_ADDR} on ${ETH_DEV}"
 
-if grep -qi kuiper "/etc/os-release"; then
-	cat <<-EOF > /etc/dhcpcd.conf
-		interface ${ETH_DEV}
-		static ip_address=${IP_ADDR}/24
-	EOF
-	systemctl daemon-reload
-	systemctl restart dhcpcd.service
-else
-	# disable NetworkManager (assumes the config file hasn't been touched much)
-	sed -i 's/^managed=false/managed=true/' /etc/NetworkManager/NetworkManager.conf
+# disable NetworkManager (assumes the config file hasn't been touched much)
+sed -i 's/^managed=false/managed=true/' /etc/NetworkManager/NetworkManager.conf
 
-	# set up loopback and add static IP config for ${ETH_DEV} (defaults to eth0)
-	cat <<-EOF > /etc/network/interfaces
-		auto lo
-		iface lo inet loopback
+# set up loopback and add static IP config for ${ETH_DEV} (defaults to eth0)
+cat <<-EOF > /etc/network/interfaces
+	auto lo
+	iface lo inet loopback
 
-		auto ${ETH_DEV}
-		iface ${ETH_DEV} inet static
-		address ${IP_ADDR}
-		netmask 255.255.255.0
-	EOF
+	auto ${ETH_DEV}
+	iface ${ETH_DEV} inet static
+	address ${IP_ADDR}
+	netmask 255.255.255.0
+EOF
 
-	systemctl restart NetworkManager
-	systemctl restart networking
-fi
+systemctl restart NetworkManager
+systemctl restart networking


### PR DESCRIPTION
Remove dhcpcd settings for networking, since Kuiper 2 only has NetworkManager and will never enter the first branch of the if statement.