### PR TITLE
Makefile: add support for deb package building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,36 @@ install:
 
 	install -D -m 0644 ./fix-display-port.service $(DESTDIR)/etc/systemd/system/fix-display-port.service
 
-ifeq ($(DESTDIR),)
-	systemctl enable adi-power.service
-	systemctl enable fan-control.service
-	systemctl enable fix-display-port.service
+	# USB gadget service files
+	install -D -m 0644 ./usb-gadget-service/systemd/gt.service $(DESTDIR)/etc/systemd/system/gt.service
+	install -D -m 0644 ./usb-gadget-service/systemd/gt-start.service $(DESTDIR)/etc/systemd/system/gt-start.service
+	install -D -m 0644 ./usb-gadget-service/systemd/gt.target $(DESTDIR)/etc/systemd/system/gt.target
+	install -D -m 0644 ./usb-gadget-service/systemd/iiod_ffs.service $(DESTDIR)/etc/systemd/system/iiod_ffs.service
+	install -D -m 0644 ./usb-gadget-service/systemd/dev-iio_ffs.mount $(DESTDIR)/etc/systemd/system/dev-iio_ffs.mount
+	install -D -m 0644 ./usb-gadget-service/systemd/iiod_context_attr.service $(DESTDIR)/etc/systemd/system/iiod_context_attr.service
 
+	install -D -m 0644 ./usb-gadget-service/defaults/usb_gadget $(DESTDIR)/etc/default/usb_gadget
+	install -D -m 0644 ./usb-gadget-service/defaults/iiod $(DESTDIR)/etc/default/iiod
+
+	install -d $(DESTDIR)/usr/share/adi-scripts/gt/schemes
+	install -m 0644 ./usb-gadget-service/schemes/iio_acm_generic.scheme $(DESTDIR)/usr/share/adi-scripts/gt/schemes/iio_acm_generic.scheme
+	install -m 0644 ./usb-gadget-service/schemes/iio_ncm.scheme $(DESTDIR)/usr/share/adi-scripts/gt/schemes/iio_ncm.scheme
+	install -m 0644 ./usb-gadget-service/schemes/iio_acmx2_rndis.scheme $(DESTDIR)/usr/share/adi-scripts/gt/schemes/iio_acmx2_rndis.scheme
+
+	install -D -m 0755 ./usb-gadget-service/scripts/iiod_context.sh $(DESTDIR)$(PREFIX)/bin/iiod_context.sh
+	install -D -m 0755 ./usb-gadget-service/scripts/usb_gadget.sh $(DESTDIR)$(PREFIX)/bin/usb_gadget.sh
+
+	install -D -m 0644 ./usb-gadget-service/udev/99-udc.rules $(DESTDIR)/etc/udev/rules.d/99-udc.rules
+
+	# Other configuration files
+	install -D -m 0644 ./fw_env.config $(DESTDIR)/etc/fw_env.config
+	install -D -m 0644 ./ttyGS0.conf $(DESTDIR)/etc/ttyGS0.conf
+	install -D -m 0644 ./input-event-daemon.conf.rfsombox $(DESTDIR)/etc/input-event-daemon.conf.rfsombox
+
+ifeq ($(DESTDIR),)
+	# Build and install gt
 	/bin/sh usb-gadget-service/install_gt.sh
+
+	systemctl enable adi-power.service fan-control.service fix-display-port.service
+	systemctl enable iiod_context_attr.service gt.service dev-iio_ffs.mount iiod_ffs.service gt-start.service gt.target
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
-DESTDIR=/usr/local
+DESTDIR ?=
+PREFIX ?= /usr/local
 
 install:
-	install -d $(DESTDIR)/bin
-	install ./*.sh $(DESTDIR)/bin/
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install ./*.sh $(DESTDIR)$(PREFIX)/bin/
 
-	install -D -m 0644 ./power-service/adi-power.service /etc/systemd/system/
-	install -D -m 0644 ./power-service/adi_power.py /usr/share/systemd/
-	install -D -m 0644 ./power-service/stingray_power.py /usr/share/systemd/
+	install -D -m 0644 ./power-service/adi-power.service $(DESTDIR)/etc/systemd/system/adi-power.service
+	install -D -m 0644 ./power-service/adi_power.py $(DESTDIR)/usr/share/systemd/adi_power.py
+	install -D -m 0644 ./power-service/stingray_power.py $(DESTDIR)/usr/share/systemd/stingray_power.py
 
-	install -D -m 0644 ./lightdm_timeout.conf /etc/systemd/system/lightdm.service.d/timeout.conf
+	install -D -m 0644 ./lightdm_timeout.conf $(DESTDIR)/etc/systemd/system/lightdm.service.d/timeout.conf
 
-	install -D -m 0644 ./jupiter_scripts/fan-control.service /etc/systemd/system/fan-control.service
-	install -D -m 0744 ./jupiter_scripts/fan-control /usr/bin/fan-control
+	install -D -m 0644 ./jupiter_scripts/fan-control.service $(DESTDIR)/etc/systemd/system/fan-control.service
+	install -D -m 0744 ./jupiter_scripts/fan-control $(DESTDIR)$(PREFIX)/bin/fan-control
 
-	install -D -m 0644 ./fix-display-port.service /etc/systemd/system/fix-display-port.service
+	install -D -m 0644 ./fix-display-port.service $(DESTDIR)/etc/systemd/system/fix-display-port.service
 
+ifeq ($(DESTDIR),)
 	systemctl enable adi-power.service
 	systemctl enable fan-control.service
 	systemctl enable fix-display-port.service
 
 	/bin/sh usb-gadget-service/install_gt.sh
+endif

--- a/usb-gadget-service/install_gt.sh
+++ b/usb-gadget-service/install_gt.sh
@@ -3,8 +3,6 @@ if [ "$(id -u)" != "0" ] ; then
 	exit 1
 fi
 
-SCRIPT_PATH=$(dirname $(readlink -f $0))
-
 apt-get -y install autoconf libtool libconfig-dev
 
 cd /usr/local/src
@@ -36,27 +34,3 @@ make && make install
 cd -
 
 ldconfig
-
-cd $SCRIPT_PATH
-
-install -D -m 0644 systemd/gt.service /etc/systemd/system/
-install -D -m 0644 systemd/gt-start.service /etc/systemd/system/
-install -D -m 0644 systemd/gt.target /etc/systemd/system/
-install -D -m 0644 systemd/iiod_ffs.service /etc/systemd/system/
-install -D -m 0644 systemd/dev-iio_ffs.mount /etc/systemd/system/
-install -D -m 0644 systemd/iiod_context_attr.service /etc/systemd/system/
-
-install -D -m 0644 -C defaults/usb_gadget /etc/default/
-install -D -m 0644 -C defaults/iiod /etc/default/
-
-install -d /usr/local/etc/gt/adi/
-install -D -m 0644 schemes/iio_acm_generic.scheme /usr/local/etc/gt/adi/
-install -D -m 0644 schemes/iio_ncm.scheme /usr/local/etc/gt/adi/
-install -D -m 0644 schemes/iio_acmx2_rndis.scheme /usr/local/etc/gt/adi/
-
-install -D -m 0744 scripts/iiod_context.sh /usr/local/bin/
-install -D -m 0744 scripts/usb_gadget.sh /usr/local/bin/
-
-install -D -m 0644 udev/99-udc.rules /etc/udev/rules.d/
-
-systemctl enable iiod_context_attr.service gt.service dev-iio_ffs.mount iiod_ffs.service gt-start.service gt.target


### PR DESCRIPTION
- add DESTDIR and PREFIX variables for installing file to generic paths
- skip systemctl/install_gt.sh when DESTDIR is set
- move USB gadget service files, schemes, scripts, and config file installation from install_gt.sh to Makefile
- install_gt.sh now only builds gt and libusbgx repos

This preserves existing behavior for normal installs while enabling Debian package builds.