### PR TITLE
Add prefix-based templating system for services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,38 @@
 DESTDIR ?=
 PREFIX ?= /usr/local
 
-install:
+# Service templates and generated files
+SERVICE_TEMPLATES = \
+	jupiter_scripts/fan-control.service.in \
+	fix-display-port.service.in \
+	power-service/adi-power.service.in \
+	usb-gadget-service/systemd/gt.service.in \
+	usb-gadget-service/systemd/gt-start.service.in \
+	usb-gadget-service/systemd/iiod_context_attr.service.in
+
+SERVICE_FILES = $(SERVICE_TEMPLATES:.service.in=.service)
+
+# Config file templates
+CONFIG_TEMPLATES = \
+	usb-gadget-service/defaults/usb_gadget.in
+
+CONFIG_FILES = $(CONFIG_TEMPLATES:.in=)
+
+# Rule to generate .service files from .service.in templates
+%.service: %.service.in
+	sed 's|@PREFIX@|$(PREFIX)|g' $< > $@
+
+# Rule to generate config files from .in templates
+usb-gadget-service/defaults/usb_gadget: usb-gadget-service/defaults/usb_gadget.in
+	sed 's|@PREFIX@|$(PREFIX)|g' $< > $@
+
+install: $(SERVICE_FILES) $(CONFIG_FILES)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install ./*.sh $(DESTDIR)$(PREFIX)/bin/
 
 	install -D -m 0644 ./power-service/adi-power.service $(DESTDIR)/etc/systemd/system/adi-power.service
-	install -D -m 0644 ./power-service/adi_power.py $(DESTDIR)/usr/share/systemd/adi_power.py
-	install -D -m 0644 ./power-service/stingray_power.py $(DESTDIR)/usr/share/systemd/stingray_power.py
+	install -D -m 0644 ./power-service/adi_power.py $(DESTDIR)$(PREFIX)/share/systemd/adi_power.py
+	install -D -m 0644 ./power-service/stingray_power.py $(DESTDIR)$(PREFIX)/share/systemd/stingray_power.py
 
 	install -D -m 0644 ./lightdm_timeout.conf $(DESTDIR)/etc/systemd/system/lightdm.service.d/timeout.conf
 
@@ -27,10 +52,10 @@ install:
 	install -D -m 0644 ./usb-gadget-service/defaults/usb_gadget $(DESTDIR)/etc/default/usb_gadget
 	install -D -m 0644 ./usb-gadget-service/defaults/iiod $(DESTDIR)/etc/default/iiod
 
-	install -d $(DESTDIR)/usr/share/adi-scripts/gt/schemes
-	install -m 0644 ./usb-gadget-service/schemes/iio_acm_generic.scheme $(DESTDIR)/usr/share/adi-scripts/gt/schemes/iio_acm_generic.scheme
-	install -m 0644 ./usb-gadget-service/schemes/iio_ncm.scheme $(DESTDIR)/usr/share/adi-scripts/gt/schemes/iio_ncm.scheme
-	install -m 0644 ./usb-gadget-service/schemes/iio_acmx2_rndis.scheme $(DESTDIR)/usr/share/adi-scripts/gt/schemes/iio_acmx2_rndis.scheme
+	install -d $(DESTDIR)$(PREFIX)/share/adi-scripts/gt/schemes
+	install -m 0644 ./usb-gadget-service/schemes/iio_acm_generic.scheme $(DESTDIR)$(PREFIX)/share/adi-scripts/gt/schemes/iio_acm_generic.scheme
+	install -m 0644 ./usb-gadget-service/schemes/iio_ncm.scheme $(DESTDIR)$(PREFIX)/share/adi-scripts/gt/schemes/iio_ncm.scheme
+	install -m 0644 ./usb-gadget-service/schemes/iio_acmx2_rndis.scheme $(DESTDIR)$(PREFIX)/share/adi-scripts/gt/schemes/iio_acmx2_rndis.scheme
 
 	install -D -m 0755 ./usb-gadget-service/scripts/iiod_context.sh $(DESTDIR)$(PREFIX)/bin/iiod_context.sh
 	install -D -m 0755 ./usb-gadget-service/scripts/usb_gadget.sh $(DESTDIR)$(PREFIX)/bin/usb_gadget.sh
@@ -49,3 +74,8 @@ ifeq ($(DESTDIR),)
 	systemctl enable adi-power.service fan-control.service fix-display-port.service
 	systemctl enable iiod_context_attr.service gt.service dev-iio_ffs.mount iiod_ffs.service gt-start.service gt.target
 endif
+
+clean:
+	rm -f $(SERVICE_FILES) $(CONFIG_FILES)
+
+.PHONY: install clean

--- a/fix-display-port.service.in
+++ b/fix-display-port.service.in
@@ -3,7 +3,7 @@ Description=Fix DP audio and X11
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c "fix_x11.sh; fix_DP_audio.sh"
+ExecStart=/bin/bash -c "@PREFIX@/bin/fix_x11.sh; @PREFIX@/bin/fix_DP_audio.sh"
 
 [Install]
 WantedBy=multi-user.target

--- a/jupiter_scripts/fan-control.service
+++ b/jupiter_scripts/fan-control.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=fan-control
-
-[Service]
-Type=simple
-ExecStart=/bin/sh -c 'grep -i -e "Jupiter SDR" /sys/firmware/devicetree/base/model && /usr/bin/fan-control'
-
-[Install]
-WantedBy=multi-user.target

--- a/jupiter_scripts/fan-control.service.in
+++ b/jupiter_scripts/fan-control.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=fan-control
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'grep -i -e "Jupiter SDR" /sys/firmware/devicetree/base/model && @PREFIX@/bin/fan-control'
+
+[Install]
+WantedBy=multi-user.target

--- a/power-service/adi-power.service.in
+++ b/power-service/adi-power.service.in
@@ -4,8 +4,8 @@ Description=Analog Devices power up/down sequence
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/usr/bin/python3 /usr/share/systemd/adi_power.py up
-ExecStop=/usr/bin/python3 /usr/share/systemd/adi_power.py down
+ExecStart=/usr/bin/python3 @PREFIX@/share/systemd/adi_power.py up
+ExecStop=/usr/bin/python3 @PREFIX@/share/systemd/adi_power.py down
 
 [Install]
 WantedBy=multi-user.target

--- a/usb-gadget-service/defaults/usb_gadget
+++ b/usb-gadget-service/defaults/usb_gadget
@@ -1,1 +1,0 @@
-GT_DEFAULT_SCHEME=/usr/local/etc/gt/adi/iio_acm_generic.scheme

--- a/usb-gadget-service/defaults/usb_gadget.in
+++ b/usb-gadget-service/defaults/usb_gadget.in
@@ -1,0 +1,1 @@
+GT_DEFAULT_SCHEME=@PREFIX@/share/adi-scripts/gt/schemes/iio_acm_generic.scheme

--- a/usb-gadget-service/systemd/gt-start.service.in
+++ b/usb-gadget-service/systemd/gt-start.service.in
@@ -11,9 +11,9 @@ After=iiod_ffs.service
 
 [Service]
 ExecStartPre=/bin/sleep 2
-ExecStart=/usr/local/bin/gt enable adi_usb_gadget
+ExecStart=@PREFIX@/bin/gt enable adi_usb_gadget
 RemainAfterExit=yes
-ExecStop=/usr/local/bin/gt disable adi_usb_gadget
+ExecStop=@PREFIX@/bin/gt disable adi_usb_gadget
 Type=oneshot
 
 [Install]

--- a/usb-gadget-service/systemd/gt.service.in
+++ b/usb-gadget-service/systemd/gt.service.in
@@ -11,9 +11,9 @@ After=sys-kernel-config.mount network.target
 
 [Service]
 EnvironmentFile=-/etc/default/usb_gadget
-ExecStart=/usr/local/bin/gt load -o $GT_DEFAULT_SCHEME adi_usb_gadget
+ExecStart=@PREFIX@/bin/gt load -o $GT_DEFAULT_SCHEME adi_usb_gadget
 RemainAfterExit=yes
-ExecStop=/usr/local/bin/gt rm -rf adi_usb_gadget
+ExecStop=@PREFIX@/bin/gt rm -rf adi_usb_gadget
 Type=oneshot
 
 [Install]

--- a/usb-gadget-service/systemd/iiod_context_attr.service.in
+++ b/usb-gadget-service/systemd/iiod_context_attr.service.in
@@ -10,7 +10,7 @@ ConditionPathExists=/sys/bus/iio
 Before=iiod.service iiod_ffs.service
 
 [Service]
-ExecStart=/bin/sh /usr/local/bin/iiod_context.sh
+ExecStart=/bin/sh @PREFIX@/bin/iiod_context.sh
 RemainAfterExit=yes
 Type=oneshot
 


### PR DESCRIPTION
Implement a template-based build system that supports both local installations (PREFIX=/usr/local) and Debian package builds (PREFIX=/usr) using a single codebase.

Changes:
- Create .service.in template files for all systemd services with @PREFIX@ placeholder substitution
- Add usb_gadget.in template for USB gadget configuration
- Update Makefile to generate service and config files from templates during build process
- Move scheme files from /etc/gt/adi/ to /share/adi-scripts/gt/schemes/ to comply with Linux FHS (data files belong in /share, not /etc)
- Fix adi-power.service to use PREFIX for Python script paths
- Add clean target to remove generated files
- Remove old .service files from git (now generated from templates)