### PR TITLE
jupiter_sdr: Fix wrong powerdown triggers

### DIFF
--- a/jupiter_scripts/fan-control
+++ b/jupiter_scripts/fan-control
@@ -45,6 +45,15 @@ daemon() {
     led_toggle
     current_temp=$(temp)
 
+    if [[ $current_temp -ge 65247000 ]]; then
+      profile_load_status=$(iio_attr -d adrv9002-phy  profile_config)
+      if [[ $profile_load_status ==  "No profile loaded..." ]]; then
+        profile_status="FAILED"
+      else
+        profile_status="OK"
+      fi
+    fi
+
     last_five=("${last_five[@]:1}")
     last_five+=("$current_temp")
 
@@ -54,7 +63,7 @@ daemon() {
     done
     average=$(expr $average / 5)
 
-    if [[ $average -ge $TEMP_POWEROFF ]]; then
+    if [[ $average -ge $TEMP_POWEROFF ]] && [[ $profile_status != "FAILED" ]]; then
       poweroff
     fi
 


### PR DESCRIPTION
The power down protection mechanism is triggered when the adrv9002 temperature exceeds 100 deg C.
With newer SW versions, when a profile load fails the read temperature function does not throw an error, it returns a hight value, causing the jupiter to trigger the power down for protection.
This commit adds a check that verifies if a profile load has failed to avoid the unwanted poweroff.