### PR TITLE
iiod_context.sh: clean up stale EEPROM context attributes on boot

### DIFF
--- a/usb-gadget-service/scripts/iiod_context.sh
+++ b/usb-gadget-service/scripts/iiod_context.sh
@@ -137,7 +137,18 @@ replace_or_add dtoverlay "${OVERLAY}"
 
 EXTRA_EEPROM_BOARDS="EVAL-CN0511-RPIZ"
 EXTRA_EEPROM_FILE="/sys/devices/platform/soc/fe804000.i2c/i2c-1/1-0051/eeprom"
+EXTRA_EEPROM_KEYS="/etc/libiio_eeprom_keys"
 CAN_READ_EXTRA_EEPROM=0
+
+# Remove stale EEPROM-sourced keys from a previous boot
+if [ -f "$EXTRA_EEPROM_KEYS" ]; then
+	while read -r KEY; do
+		if [ -n "$KEY" ]; then
+			remove "$KEY"
+		fi
+	done < "$EXTRA_EEPROM_KEYS"
+	rm -f "$EXTRA_EEPROM_KEYS"
+fi
 
 if echo "$EXTRA_EEPROM_BOARDS" | grep -w -q "$NAME"; then
 	CAN_READ_EXTRA_EEPROM=1
@@ -150,6 +161,7 @@ if [ "$CAN_READ_EXTRA_EEPROM" = "1" -a -f "$EXTRA_EEPROM_FILE" ]; then
 		EOF
 		if [ -n "$KEY" -a -n "$VALUE" ]; then
 			replace_or_add "$KEY" "$VALUE"
+			echo "$KEY" >> "$EXTRA_EEPROM_KEYS"
 		fi
 	done < "$EXTRA_EEPROM_FILE"
 fi


### PR DESCRIPTION
Cherry picked commit

"Track EEPROM-sourced keys in /etc/libiio_eeprom_keys and remove them on the next boot before re-reading the EEPROM. This prevents stale calibration data from persisting when switching boards.

Fixes: https://github.com/analogdevicesinc/linux_image_ADI-scripts/commit/11ead4cc2eaf5a7ff01a39d08d44fd481538d679 ("iiod_context: append key=value pairs found in extra eeprom to libiio.ini")"